### PR TITLE
Add support for lists of tactics

### DIFF
--- a/raidengine/raidengine.go
+++ b/raidengine/raidengine.go
@@ -17,13 +17,23 @@ import (
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-// StrikeResult is a struct that contains the results of a test
+// MovementResult is a struct that contains the results of a single step within a strike
+type MovementResult struct {
+	Passed      bool        // Passed is true if the test passed
+	Description string      // Description is a human-readable description of the test
+	Message     string      // Message is a human-readable description of the test result
+	Function    string      // Function is the name of the code that was executed
+	Value       interface{} // Value is the object that was returned during the movement
+}
+
+// StrikeResult is a struct that contains the results of a check for a single control
 type StrikeResult struct {
-	Passed      bool   // Passed is true if the test passed
-	Description string // Description is a human-readable description of the test
-	Message     string // Message is a human-readable description of the test result
-	DocsURL     string // DocsURL is a link to the documentation for the test
-	ControlID   string // ControlID is the ID of the control that the test is validating
+	Passed      bool                      // Passed is true if the test passed
+	Description string                    // Description is a human-readable description of the test
+	Message     string                    // Message is a human-readable description of the test result
+	DocsURL     string                    // DocsURL is a link to the documentation for the test
+	ControlID   string                    // ControlID is the ID of the control that the test is validating
+	Movements   map[string]MovementResult // Movements is a list of functions that were executed during the test
 }
 
 // RaidResults is a struct that contains the results of all strikes, orgainzed by name


### PR DESCRIPTION
Follows #3.

The config may now stipulate a single `tactic` string or a list of strings in `tactics`. Tactics will supersede tactic. 

Output will now be sorted according to the tactic used:
<img width="289" alt="Screenshot 2023-10-17 at 9 54 28 PM" src="https://github.com/privateerproj/privateer-sdk/assets/21176439/a75059f3-f58d-405c-8c38-f7a4ce99870b">

If a strike falls under multiple tactics, the `ControlID` for the active tactic will be logged.

Enabling this required moving quite a bit of logic out of the wireframe to keep everything cohesive— so that's a side benefit. Previous versions of the wireframe will break with this change.