### PR TITLE
Added common logic for running a movement

### DIFF
--- a/raidengine/raidengine.go
+++ b/raidengine/raidengine.go
@@ -167,6 +167,25 @@ func getFunctionAddress(i Strike) string {
 	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 }
 
+// RunMovement is a helper function to run a movement function and update the result
+func ExecuteMovement(strikeResult *raidengine.StrikeResult, movementFunc func() raidengine.MovementResult) {
+	// get name of movementFunc as string
+	movementFuncName := runtime.FuncForPC(reflect.ValueOf(movementFunc).Pointer()).Name()
+	// get the last part of the name, which is the actual function name
+	movementName := strings.Split(movementFuncName, ".")[len(strings.Split(movementFuncName, "."))-1]
+
+	movementResult := movementFunc()
+
+	// update the parent strike result with the movement result
+	strikeResult.Movements[movementName] = movementResult
+	if !movementResult.Passed {
+		strikeResult.Message = movementResult.Message
+		return
+	}
+	strikeResult.Passed = true
+	return
+}
+
 // SetupCloseHandler sets the cleanup function to be called when the program is interrupted
 func SetupCloseHandler(customFunction cleanupFunc) {
 	cleanup = customFunction


### PR DESCRIPTION
Replaces the following repetitive raid code: 

```go
	CCC_C01_TR01_T01_Result := CCC_C01_TR01_T01()
	result.Movements["CCC_C01_TR01_T01"] = CCC_C01_TR01_T01_Result
	if !CCC_C01_TR01_T01_Result.Passed {
		result.Message = CCC_C01_TR01_T01_Result.Message
		return
	}
```

with the updated:

```go
	raidengine.ExecuteMovement(&result, CCC_C01_TR01_T01)
```
