### PR TITLE
Update Strike Result Regardless

### DIFF
--- a/raidengine/raidengine.go
+++ b/raidengine/raidengine.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"reflect"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/spf13/viper"
@@ -179,12 +179,8 @@ func ExecuteMovement(strikeResult *StrikeResult, movementFunc func() MovementRes
 
 	// update the parent strike result with the movement result
 	strikeResult.Movements[movementName] = movementResult
-	if !movementResult.Passed {
-		strikeResult.Message = movementResult.Message
-		return
-	}
-	strikeResult.Passed = true
-	return
+	strikeResult.Passed = movementResult.Passed
+	strikeResult.Message = movementResult.Message
 }
 
 // SetupCloseHandler sets the cleanup function to be called when the program is interrupted


### PR DESCRIPTION
This solves for the following problem:

```yaml
    CCC_C01_TR01:
        passed: true
        description: The service enforces the use of secure transport protocols for all network communications (e.g., TLS 1.2 or higher).
        message: Strike has not yet started.
        docsurl: https://maintainer.com/docs/raids/ABS
        controlid: CCC.C01
        movements:
            CCC_C01_TR01_T01:
                passed: true
                description: Checking TLS version of response
                message: TLS 1.3 is being used
                function: github.com/privateerproj/privateer-pack-ABS/armory.CCC_C01_TR01_T01
                value: null
```