### PR TITLE
Fix: Added passthrough for raid required variables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,8 @@ func NewConfig(requiredVars []string) Config {
 
 	var missingVars []string
 	for _, v := range requiredVars {
-		if _, ok := vars[v]; !ok {
+		found := viper.Get(fmt.Sprintf("services.%s.vars.%s", serviceName, v))
+		if found == nil || found == "" {
 			missingVars = append(missingVars, v)
 		}
 	}

--- a/raidengine/tactic_test.go
+++ b/raidengine/tactic_test.go
@@ -40,7 +40,7 @@ func TestTacticExecute(t *testing.T) {
 	viper.Set("WriteDirectory", "./tmp")
 	for _, tt := range tacticTestData {
 		viper.Set(fmt.Sprintf("raids.%s.tactics", tt.raidName), tt.tacticNames)
-		goodVessel.StockArmory(tt.armory)
+		goodVessel.StockArmory(tt.armory, nil)
 
 		t.Run(tt.testName, func(t *testing.T) {
 			tactic := Tactic{

--- a/raidengine/vessel.go
+++ b/raidengine/vessel.go
@@ -20,13 +20,13 @@ type Vessel struct {
 }
 
 // StockArmory sets up the armory for the vessel to use
-func (v *Vessel) StockArmory(armory *Armory) error {
+func (v *Vessel) StockArmory(armory *Armory, requiredVars []string) error {
 	if armory == nil {
 		return fmt.Errorf("armory cannot be nil")
 	}
 	if v.logger == nil {
 		if v.config == nil {
-			config := config.NewConfig(nil)
+			config := config.NewConfig(requiredVars)
 			v.config = &config
 		}
 	}
@@ -57,7 +57,11 @@ func (v *Vessel) StockArmory(armory *Armory) error {
 }
 
 // Mobilize executes the strikes specified in the tactics
-func (v *Vessel) Mobilize() (err error) {
+func (v *Vessel) Mobilize(armory *Armory, requiredVars []string) (err error) {
+	err = v.StockArmory(armory, requiredVars)
+	if err != nil {
+		return
+	}
 	if v.config == nil {
 		err = fmt.Errorf("config cannot be nil")
 		return
@@ -69,7 +73,7 @@ func (v *Vessel) Mobilize() (err error) {
 		}
 
 		tactic := Tactic{
-			TacticName:      tacticName, // TODO: We should probably find a prettier way to name these
+			TacticName:      tacticName,
 			strikes:         v.armory.Tactics[tacticName],
 			executedStrikes: v.executedStrikes,
 			config:          v.config,


### PR DESCRIPTION
Also moved `StockArmory` into `Mobilize` since it will always/only be called in that sequence