### PR TITLE
feat: changed vessel to use fields instead of args

### DIFF
--- a/raidengine/tactic_test.go
+++ b/raidengine/tactic_test.go
@@ -40,7 +40,8 @@ func TestTacticExecute(t *testing.T) {
 	viper.Set("WriteDirectory", "./tmp")
 	for _, tt := range tacticTestData {
 		viper.Set(fmt.Sprintf("raids.%s.tactics", tt.raidName), tt.tacticNames)
-		goodVessel.StockArmory(tt.armory, nil)
+		goodVessel.Armory = tt.armory
+		goodVessel.StockArmory()
 
 		t.Run(tt.testName, func(t *testing.T) {
 			tactic := Tactic{

--- a/raidengine/vessel_test.go
+++ b/raidengine/vessel_test.go
@@ -120,7 +120,7 @@ var tests = []struct {
 		serviceName:   "missingArmory",
 		vessel:        goodVessel,
 		armory:        nil,
-		expectedError: errors.New("armory cannot be nil"),
+		expectedError: errors.New("vessel's Armory field cannot be nil"),
 	},
 	{
 		name:          "missing tactics",
@@ -186,8 +186,9 @@ func TestVessel_Mobilize(t *testing.T) {
 			viper.Set("write-directory", "./tmp")
 			viper.Set("services."+tt.serviceName+".tactics", tt.tacticRequest)
 			viper.Set("services."+tt.serviceName+".vars", map[string]interface{}{"key": "value"})
-
-			err := tt.vessel.Mobilize(tt.armory, tt.requiredVars)
+			tt.vessel.Armory = tt.armory
+			tt.vessel.RequiredVars = tt.requiredVars
+			err := tt.vessel.Mobilize()
 
 			if tt.expectedError != nil {
 				if err == nil {


### PR DESCRIPTION
This pull request includes changes to the `raidengine` package to refactor how the `Armory` and `RequiredVars` are handled in the `Vessel` struct. The most important changes include modifying the `Vessel` struct to directly include the `Armory` and `RequiredVars` fields, updating the `StockArmory` and `Mobilize` methods accordingly, and adjusting the associated tests.