### PR TITLE
feat: rename raid to plugin

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -22,7 +22,7 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("service", "s", "", "Named service to execute from the config")
 	viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
 
-	cmd.PersistentFlags().StringP("tactic", "t", "default", "Named set of strikes to execute from the raid")
+	cmd.PersistentFlags().StringP("tactic", "t", "default", "Named set of strikes to execute from the plugin")
 	viper.BindPFlag("tactic", cmd.PersistentFlags().Lookup("tactic"))
 
 	cmd.PersistentFlags().BoolP("silent", "", false, "Shh! Only show essential log information")

--- a/config/config.go
+++ b/config/config.go
@@ -105,10 +105,10 @@ func (c *Config) SetConfig(name string, jsonFormat bool) {
 	var logFilePath string
 	logFile := name + ".log"
 	if name == "overview" {
-		// if this is not a raid, do not nest within a directory
+		// if this is not a plugin, do not nest within a directory
 		logFilePath = path.Join(c.WriteDirectory, logFile)
 	} else {
-		// otherwise, nest within a directory with the same name as the raid
+		// otherwise, nest within a directory with the same name as the plugin
 		logFilePath = path.Join(c.WriteDirectory, name, logFile)
 	}
 

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -7,8 +7,8 @@ import (
 	hcplugin "github.com/hashicorp/go-plugin"
 )
 
-// RaidPluginName overwritten to be used by Privateer Core sally.go: rpcClient.Dispense(plugin.RaidPluginName)
-const RaidPluginName = "raid"
+// PluginName overwritten to be used by Privateer Core sally.go: rpcClient.Dispense(plugin.PluginName)
+const PluginName = "plugin"
 
 // handshakeConfigs are used to just do a basic handshake between
 // a hcplugin and host. If the handshake fails, a user friendly error is shown.
@@ -19,7 +19,7 @@ var handshakeConfig = GetHandshakeConfig()
 // ServeOpts are the configurations to serve a plugin.
 type ServeOpts struct {
 	//Interface implementation
-	Plugin Raid
+	Plugin Pluginer
 
 	// Logger is the logger that go-plugin will use.
 	Logger hclog.Logger
@@ -27,7 +27,7 @@ type ServeOpts struct {
 
 // Serve serves a plugin. This function never returns and should be the final
 // function called in the main function of the plugin.
-func Serve(raidName string, opts *ServeOpts) {
+func Serve(pluginName string, opts *ServeOpts) {
 	// Guard Clause: Ensure plugin is not nil
 	if opts.Plugin == nil {
 		log.Panic("Invalid (nil) plugin implementation provided")
@@ -35,7 +35,7 @@ func Serve(raidName string, opts *ServeOpts) {
 
 	// hcpluginMap is the map of hcplugins we can dispense.
 	var hcpluginMap = map[string]hcplugin.Plugin{
-		RaidPluginName: &RaidPlugin{Impl: opts.Plugin},
+		PluginName: &Plugin{Impl: opts.Plugin},
 	}
 
 	hcplugin.Serve(&hcplugin.ServeConfig{
@@ -43,14 +43,14 @@ func Serve(raidName string, opts *ServeOpts) {
 		Plugins:         hcpluginMap,
 		Logger:          opts.Logger,
 	})
-	log.Printf("Successfully completed raid: %s", raidName)
+	log.Printf("Successfully completed plugin: %s", pluginName)
 }
 
 // GetHandshakeConfig provides handshake config details. It is used by core and service packs.
 func GetHandshakeConfig() hcplugin.HandshakeConfig {
 	return hcplugin.HandshakeConfig{
 		ProtocolVersion:  1,
-		MagicCookieKey:   "PVTR_MAGIC_COOKIE",
-		MagicCookieValue: "privateer.raid",
+		MagicCookieKey:   "PVTR_MAGIC_COOKIE_KEY",
+		MagicCookieValue: "privateer.plugin",
 	}
 }

--- a/pluginkit/armory.go
+++ b/pluginkit/armory.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"github.com/hashicorp/go-hclog"
@@ -6,7 +6,7 @@ import (
 )
 
 type Armory struct {
-	RaidName      string
+	PluginName    string
 	ServiceTarget string
 	Config        *config.Config
 	Logger        hclog.Logger

--- a/pluginkit/change.go
+++ b/pluginkit/change.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"fmt"

--- a/pluginkit/change_test.go
+++ b/pluginkit/change_test.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import "testing"
 

--- a/pluginkit/movement.go
+++ b/pluginkit/movement.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 type Movement func() *MovementResult
 

--- a/pluginkit/strike.go
+++ b/pluginkit/strike.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"log"
@@ -21,7 +21,7 @@ type StrikeResult struct {
 	Movements     map[string]MovementResult // Movements is a list of functions that were executed during the test
 	BadStateAlert bool                      // BadStateAlert is true if any change failed to revert at the end of the strike
 
-	invasiveRaid bool // invasiveRaid is true if the tactic is allowed to make changes to the target service
+	invasivePlugin bool // invasivePlugin is true if the tactic is allowed to make changes to the target service
 }
 
 func (s *StrikeResult) followThrough() {
@@ -55,7 +55,7 @@ func (s *StrikeResult) ExecuteMovement(movementFunc func() MovementResult) {
 
 // ExecuteInvasiveMovement is a helper function to run a movement function and update the result
 func (s *StrikeResult) ExecuteInvasiveMovement(movementFunc func() MovementResult) {
-	if s.invasiveRaid {
+	if s.invasivePlugin {
 		s.ExecuteMovement(movementFunc)
 	} else {
 		log.Printf("[Trace] Invasive movements are disabled, skipping movement: %s", utils.CallerName(0))

--- a/pluginkit/strike_test.go
+++ b/pluginkit/strike_test.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"fmt"

--- a/pluginkit/tactic.go
+++ b/pluginkit/tactic.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"encoding/json"
@@ -20,13 +20,13 @@ import (
 // Tactic is a struct that contains the results of all strikes, orgainzed by name
 type Tactic struct {
 	TacticName    string                  // TacticName is the name of the Tactic
-	StartTime     string                  // StartTime is the time the raid started
-	EndTime       string                  // EndTime is the time the raid ended
+	StartTime     string                  // StartTime is the time the plugin started
+	EndTime       string                  // EndTime is the time the plugin ended
 	StrikeResults map[string]StrikeResult // StrikeResults is a map of strike names to their results
 	Passed        bool                    // Passed is true if all strikes in the tactic passed
 	BadStateAlert bool                    // BadState is true if any strike failed to revert at the end of the tactic
 
-	config          *config.Config // config is the global configuration for the raid
+	config          *config.Config // config is the global configuration for the plugin
 	strikes         []Strike       // strikes is a list of strike functions for the current tactic
 	attempts        int            // attempts is the number of strikes attempted
 	successes       int            // successes is the number of successful strikes
@@ -34,7 +34,7 @@ type Tactic struct {
 	executedStrikes *[]string      // executedStrikes is a list of strikes that have been executed
 }
 
-// ExecuteTactic is used to execute a list of strikes provided by a Raid and customized by user config
+// ExecuteTactic is used to execute a list of strikes provided by a Plugin and customized by user config
 func (t *Tactic) Execute() error {
 	if t.TacticName == "" {
 		return errors.New("Tactic name was not provided before attempting to execute")
@@ -96,7 +96,7 @@ func (t *Tactic) AddStrikeResult(name string, result StrikeResult) {
 
 // WriteStrikeResultsJSON unmarhals the Tactic into a JSON file in the user's WriteDirectory
 func (t *Tactic) WriteStrikeResultsJSON() error {
-	// Log an error if RaidName was not provided
+	// Log an error if PluginName was not provided
 	if t.TacticName == "" {
 		return errors.New("Tactic name was not provided before attempting to write results")
 	}
@@ -132,7 +132,7 @@ func (t *Tactic) WriteStrikeResultsJSON() error {
 
 // WriteStrikeResultsYAML unmarhals the Tactic into a YAML file in the user's WriteDirectory
 func (t *Tactic) WriteStrikeResultsYAML(serviceName string) error {
-	// Log an error if RaidName was not provided
+	// Log an error if PluginName was not provided
 	if t.TacticName == "" || serviceName == "" {
 		return fmt.Errorf("tactic name and service name must be provided before attempting to write results: tactic='%s' service='%s'", t.TacticName, serviceName)
 	}
@@ -144,7 +144,7 @@ func (t *Tactic) WriteStrikeResultsYAML(serviceName string) error {
 	// Create log file and directory if it doesn't exist
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		os.MkdirAll(dir, os.ModePerm)
-		t.config.Logger.Error("write directory for this raid created for results, but should have been created when initializing logs:" + dir)
+		t.config.Logger.Error("write directory for this plugin created for results, but should have been created when initializing logs:" + dir)
 	}
 
 	os.Create(filepath)
@@ -189,7 +189,7 @@ func (t *Tactic) closeHandler() {
 	go func() {
 		<-c
 		t.config.Logger.Error("[ERROR] Execution aborted - %v", "SIGTERM")
-		t.config.Logger.Warn("[WARN] Attempting to revert changes made by the terminated Raid. Do not interrupt this process.")
+		t.config.Logger.Warn("[WARN] Attempting to revert changes made by the terminated Plugin. Do not interrupt this process.")
 		if t.cleanup() {
 			t.config.Logger.Info("Cleanup did not encounter an error.")
 		} else {

--- a/pluginkit/tactic_test.go
+++ b/pluginkit/tactic_test.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"fmt"
@@ -9,26 +9,26 @@ import (
 
 var tacticTestData = []struct {
 	testName    string
-	raidName    string
+	pluginName  string
 	armory      *Armory
 	runErr      string
 	tacticNames []string
 	tacticName  string
 }{
 	{
-		testName: "No tacticNames specified",
-		raidName: "testRaid",
-		armory:   goodArmory,
+		testName:   "No tacticNames specified",
+		pluginName: "testPlugin",
+		armory:     goodArmory,
 	},
 	{
 		testName:   "Single tacticName specified as 'tactic'",
-		raidName:   "testRaid",
+		pluginName: "testPlugin",
 		tacticName: "testTactic",
 		armory:     goodArmory,
 	},
 	{
 		testName:    "Single tacticName specified in 'tactics' slice",
-		raidName:    "testRaid",
+		pluginName:  "testPlugin",
 		tacticNames: []string{"testTactic"},
 		armory:      goodArmory,
 	},
@@ -36,10 +36,10 @@ var tacticTestData = []struct {
 
 func TestTacticExecute(t *testing.T) {
 
-	// test cases using testArmory and testData from raidengine_test.go
+	// test cases using testArmory and testData from pluginkit_test.go
 	viper.Set("WriteDirectory", "./tmp")
 	for _, tt := range tacticTestData {
-		viper.Set(fmt.Sprintf("raids.%s.tactics", tt.raidName), tt.tacticNames)
+		viper.Set(fmt.Sprintf("plugins.%s.tactics", tt.pluginName), tt.tacticNames)
 		goodVessel.Armory = tt.armory
 		goodVessel.StockArmory()
 

--- a/pluginkit/vessel.go
+++ b/pluginkit/vessel.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"errors"
@@ -11,7 +11,7 @@ import (
 // The vessel gets the armory in position to execute the strikes specified in the tactics
 type Vessel struct {
 	ServiceName     string
-	RaidName        string
+	PluginName      string
 	RequiredVars    []string
 	Armory          *Armory
 	Tactics         []Tactic
@@ -43,11 +43,11 @@ func (v *Vessel) StockArmory() error {
 	v.logger = v.config.Logger
 	v.ServiceName = v.config.ServiceName
 
-	if v.RaidName == "" || v.ServiceName == "" {
-		return fmt.Errorf("expected service and raid names to be set. ServiceName='%s' RaidName='%s'", v.ServiceName, v.RaidName)
+	if v.PluginName == "" || v.ServiceName == "" {
+		return fmt.Errorf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", v.ServiceName, v.PluginName)
 	}
 	if v.Armory == nil {
-		return fmt.Errorf("no armory was stocked for the raid '%s'", v.RaidName)
+		return fmt.Errorf("no armory was stocked for the plugin '%s'", v.PluginName)
 	}
 	if v.Armory.Tactics == nil {
 		return fmt.Errorf("no tactics provided for the service")

--- a/pluginkit/vessel_test.go
+++ b/pluginkit/vessel_test.go
@@ -1,4 +1,4 @@
-package raidengine
+package pluginkit
 
 import (
 	"errors"
@@ -96,7 +96,7 @@ var goodArmory = &Armory{
 	},
 }
 var goodVessel = Vessel{
-	RaidName: "TestRaid",
+	PluginName: "TestPlugin",
 }
 
 var tests = []struct {
@@ -109,11 +109,11 @@ var tests = []struct {
 	expectedError error
 }{
 	{
-		name:          "missing service and raid names",
+		name:          "missing service and plugin names",
 		serviceName:   "",
 		vessel:        Vessel{},
 		armory:        goodArmory,
-		expectedError: errors.New("expected service and raid names to be set. ServiceName='' RaidName=''"),
+		expectedError: errors.New("expected service and plugin names to be set. ServiceName='' PluginName=''"),
 	},
 	{
 		name:          "missing armory",


### PR DESCRIPTION
This pull request includes significant changes to rename and refactor the codebase from using the term "raid" to "plugin". The changes affect various files and identifiers to reflect this new terminology.

- [x] raid -> plugin
- [x] raidengine -> pluginkit
- [x] Raid/Plugin interface -> Pluginer