### PR TITLE
feat: designate output type

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -14,22 +14,22 @@ import (
 // SetBase sets the base flags for all commands
 func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("config", "c", defaultConfigPath(), "Configuration File, JSON or YAML")
-	viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
+	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 
 	cmd.PersistentFlags().StringP("loglevel", "l", "error", "Log level (trace, debug, info, warn, error, off)")
-	viper.BindPFlag("loglevel", cmd.PersistentFlags().Lookup("loglevel"))
+	_ = viper.BindPFlag("loglevel", cmd.PersistentFlags().Lookup("loglevel"))
 
 	cmd.PersistentFlags().StringP("service", "s", "", "Named service to execute from the config")
-	viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
+	_ = viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
 
 	cmd.PersistentFlags().StringP("test-suites", "t", "default", "Named set of test sets to execute from the plugin")
-	viper.BindPFlag("test-suites", cmd.PersistentFlags().Lookup("test-suites"))
+	_ = viper.BindPFlag("test-suites", cmd.PersistentFlags().Lookup("test-suites"))
 
-	cmd.PersistentFlags().BoolP("silent", "", false, "Shh! Only show essential log information")
-	viper.BindPFlag("silent", cmd.PersistentFlags().Lookup("silent"))
+	cmd.PersistentFlags().BoolP("silent", "", false, "Only show essential log information")
+	_ = viper.BindPFlag("silent", cmd.PersistentFlags().Lookup("silent"))
 
 	cmd.PersistentFlags().BoolP("write", "", true, "Keep all of the detailed result outputs in a file. Disabling does not disable log files.")
-	viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
+	_ = viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
 
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }

--- a/pluginkit/armory.go
+++ b/pluginkit/armory.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Armory struct {
-	PluginName    string
-	ServiceTarget string
-	Config        *config.Config
-	Logger        hclog.Logger
-	TestSuites    map[string][]TestSet
-	StartupFunc   func() error
-	CleanupFunc   func() error
+	PluginName    string               `json:"pluginName"`    // PluginName is the name of the plugin
+	ServiceTarget string               `json:"serviceTarget"` // ServiceTarget is the name of the service the plugin is running on
+	Config        *config.Config       `json:"config"`        // Config is the global configuration for the plugin
+	Logger        hclog.Logger         `json:"logger"`        // Logger is the global logger for the plugin
+	TestSuites    map[string][]TestSet `json:"testSuites"`    // TestSuites is a map of testSuite names to their testSets
+	StartupFunc   func() error         `json:"startupFunc"`   // StartupFunc is a function to run before the testSets
+	CleanupFunc   func() error         `json:"cleanupFunc"`   // CleanupFunc is a function to run after the testSets
 }

--- a/pluginkit/change.go
+++ b/pluginkit/change.go
@@ -7,13 +7,13 @@ import (
 
 // Change is a struct that contains the data and functions associated with a single change
 type Change struct {
-	TargetName   string                      // TargetName is the name of the resource or configuration that was changed
-	TargetObject interface{}                 // TargetObject is the object that was changed
+	TargetName   string                      `json:"targetName"`   // TargetName is the name of the resource or configuration that was changed
+	TargetObject interface{}                 `json:"targetObject"` // TargetObject is the object that was changed
+	Applied      bool                        `json:"applied"`      // Applied is true if the change was successfully applied at least once
+	Reverted     bool                        `json:"reverted"`     // Reverted is true if the change was successfully reverted and not applied again
+	Error        error                       `json:"error"`        // Error is used if an error occurred during the change
 	applyFunc    func() (interface{}, error) // Apply is the function that can be executed to make the change
 	revertFunc   func() error                // Revert is the function that can be executed to revert the change
-	Applied      bool                        // Applied is true if the change was successfully applied at least once
-	Reverted     bool                        // Reverted is true if the change was successfully reverted and not applied again
-	Error        error                       // Error is used if an error occurred during the change
 }
 
 // NewChange creates a new Change struct with the provided data

--- a/pluginkit/test.go
+++ b/pluginkit/test.go
@@ -4,12 +4,12 @@ type Test func() *TestResult
 
 // TestResult is a struct that contains the results of a single step within a testSet
 type TestResult struct {
-	Passed      bool               // Passed is true if the test passed
-	Description string             // Description is a human-readable description of the test
-	Message     string             // Message is a human-readable description of the test result
-	Function    string             // Function is the name of the code that was executed
-	Value       interface{}        // Value is the object that was returned during the test
-	Changes     map[string]*Change // Changes is a slice of changes that were made during the test
+	Passed      bool               `json:"passed"`      // Passed is true if the test passed
+	Description string             `json:"description"` // Description is a human-readable description of the test
+	Message     string             `json:"message"`     // Message is a human-readable description of the test result
+	Function    string             `json:"functin"`     // Function is the name of the code that was executed
+	Value       interface{}        `json:"value"`       // Value is the object that was returned during the test
+	Changes     map[string]*Change `json:"changes"`     // Changes is a slice of changes that were made during the test
 }
 
 func (t *TestResult) Pass(message string, value interface{}) {

--- a/pluginkit/test.go
+++ b/pluginkit/test.go
@@ -7,7 +7,7 @@ type TestResult struct {
 	Passed      bool               `json:"passed"`      // Passed is true if the test passed
 	Description string             `json:"description"` // Description is a human-readable description of the test
 	Message     string             `json:"message"`     // Message is a human-readable description of the test result
-	Function    string             `json:"functin"`     // Function is the name of the code that was executed
+	Function    string             `json:"function"`     // Function is the name of the code that was executed
 	Value       interface{}        `json:"value"`       // Value is the object that was returned during the test
 	Changes     map[string]*Change `json:"changes"`     // Changes is a slice of changes that were made during the test
 }

--- a/pluginkit/test_set.go
+++ b/pluginkit/test_set.go
@@ -13,13 +13,13 @@ type TestSet func() (testSetName string, result TestSetResult)
 
 // TestSetResult is a struct that contains the results of a check for a single control
 type TestSetResult struct {
-	Passed        bool                      // Passed is true if the test passed
-	Description   string                    // Description is a human-readable description of the test
-	Message       string                    // Message is a human-readable description of the test result
-	DocsURL       string                    // DocsURL is a link to the documentation for the test
-	ControlID     string                    // ControlID is the ID of the control that the test is validating
-	Tests         map[string]TestResult     // Tests is a list of functions that were executed during the test
-	BadStateAlert bool                      // BadStateAlert is true if any change failed to revert at the end of the testSet
+	Passed        bool                  `json:"passed"`        // Passed is true if the test passed
+	Description   string                `json:"description"`   // Description is a human-readable description of the test
+	Message       string                `json:"message"`       // Message is a human-readable description of the test result
+	DocsURL       string                `json:"docsURL"`       // DocsURL is a link to the documentation for the test
+	ControlID     string                `json:"controlID"`     // ControlID is the ID of the control that the test is validating
+	Tests         map[string]TestResult `json:"tests"`         // Tests is a list of functions that were executed during the test
+	BadStateAlert bool                  `json:"badStateAlert"` // BadStateAlert is true if any change failed to revert at the end of the testSet
 
 	invasivePlugin bool // invasivePlugin is true if the testSuite is allowed to make changes to the target service
 }

--- a/pluginkit/test_suite.go
+++ b/pluginkit/test_suite.go
@@ -140,7 +140,7 @@ func (t *TestSuite) writeTestSetResultsToFile(serviceName string, result []byte,
 			t.config.Logger.Error("Error creating directory", "directory", dir)
 			return err
 		}
-		t.config.Logger.Info("write directory for this plugin created for results, but should have been created when initializing logs", "directory", dir)
+		t.config.Logger.Warn("write directory for this plugin created for results, but should have been created when initializing logs", "directory", dir)
 	}
 
 	_, err := os.Create(filepath)

--- a/pluginkit/vessel.go
+++ b/pluginkit/vessel.go
@@ -10,12 +10,12 @@ import (
 
 // The vessel gets the armory in position to execute the testSets specified in the testSuites
 type Vessel struct {
-	ServiceName      string
-	PluginName       string
-	RequiredVars     []string
-	Armory           *Armory
-	TestSuites       []TestSuite
-	Initializer      func(*config.Config) error
+	ServiceName      string                     `json:"serviceName"`
+	PluginName       string                     `json:"pluginName"`
+	RequiredVars     []string                   `json:"requiredVars"`
+	Armory           *Armory                    `json:"armory"`
+	TestSuites       []TestSuite                `json:"testSuites"`
+	Initializer      func(*config.Config) error `json:"initializer"`
 	config           *config.Config
 	logger           hclog.Logger
 	executedTestSets *[]string
@@ -93,12 +93,13 @@ func (v *Vessel) Mobilize() (err error) {
 	}
 	v.config.Logger.Trace("Mobilization complete")
 
-	// loop through the testSuites and write the results
 	if !v.config.Write {
 		return
 	}
+
+	// loop through the testSuites and write the results
 	for _, testSuite := range v.TestSuites {
-		err := testSuite.WriteTestSetResultsYAML(v.ServiceName)
+		err := testSuite.WriteTestSetResults(v.ServiceName, v.config.Output)
 		if err != nil {
 			v.config.Logger.Error("Failed to write results for testSuite",
 				"testSuite", testSuite.TestSuiteName,


### PR DESCRIPTION
- [x] add json tags to all structs so serialization is "automated"
- [x] add ability for user to designate output type in config
  - ensure only json and yaml are output types allowed
- [x] if `write` is missing or false explicitly, only write logs to stdout
- [x] add tests on output logic
- [x] rename expected test attributes to be prefixed with `expected` (not suffixed)

comment out test proving `write` config option defaults to `true` when not present.  This is set by cobra and we currently don't include cobra setup in our `config_test.go`.  Will do quick follow PR for this.  Want this PR merged so we can have both `output` (json|yaml) and `write` (on|off).

<details><summary>Existing stdout YAML output example</summary>
<p>

```yaml
2025-01-20T13:44:38.975-0600 [TRACE] Creating a new config instance for service: serviceName=my-cloud-service1 loglevel=trace write=true write-directory=/Users/jmeridth/.privateer/logs/2025-01-20T134438-0600 invasive=false test-suites=["tlp_red"] vars=map[] output=yaml
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C01: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C01: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C02: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C03: testSet did not return a result, and may still be under development
loglevel: trace
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C04: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C04: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C05: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C05: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C05: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C05: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C06: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C06: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C07: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.975-0600 [ERROR] CCC.C07: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C08: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C08: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C09: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C09: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C09: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C10: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C11: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C11: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C11: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.C11: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.VPC.C01: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.VPC.C02: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.VPC.C03: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [ERROR] CCC.VPC.C04: testSet did not return a result, and may still be under development
2025-01-20T13:44:38.976-0600 [TRACE] Mobilization complete
2025-01-20T13:44:38.977-0600 [TRACE] Writing results: filepath=/Users/jmeridth/.privateer/logs/2025-01-20T134438-0600/my-cloud-service1/tlp_red.yaml
2025-01-20T13:44:38.978-0600 [INFO]  2025/01/20 13:44:38 tlp_red: 0/33 test sets succeeded
```

</p>
</details> 

<details><summary>stdout JSON output example</summary>
<p>

```json
{"@level":"trace","@message":"Creating a new config instance for service","@timestamp":"2025-01-20T13:44:52.611382-06:00","invasive":false,"loglevel":"trace","output":"json","serviceName":"my-cloud-service1","test-suites":["tlp_red"],"vars":{},"write":true,"write-directory":"/Users/jmeridth/.privateer/logs/2025-01-20T134452-0600"}
{"@level":"error","@message":"CCC.C01: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611764-06:00"}
{"@level":"error","@message":"CCC.C01: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611796-06:00"}
{"@level":"error","@message":"CCC.C02: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611818-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611834-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611848-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611862-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611876-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611890-06:00"}
{"@level":"error","@message":"CCC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611904-06:00"}
{"@level":"error","@message":"CCC.C04: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611919-06:00"}
{"@level":"error","@message":"CCC.C04: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611931-06:00"}
{"@level":"error","@message":"CCC.C05: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611944-06:00"}
{"@level":"error","@message":"CCC.C05: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611957-06:00"}
{"@level":"error","@message":"CCC.C05: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611969-06:00"}
{"@level":"error","@message":"CCC.C05: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611983-06:00"}
{"@level":"error","@message":"CCC.C06: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.611996-06:00"}
{"@level":"error","@message":"CCC.C06: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612008-06:00"}
{"@level":"error","@message":"CCC.C07: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612025-06:00"}
{"@level":"error","@message":"CCC.C07: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612038-06:00"}
{"@level":"error","@message":"CCC.C08: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612051-06:00"}
{"@level":"error","@message":"CCC.C08: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612071-06:00"}
{"@level":"error","@message":"CCC.C09: testSet did not return a result, and may still be under development","@timestamp":"2025-01-
20T13:44:52.612085-06:00"}
{"@level":"error","@message":"CCC.C09: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612097-06:00"}
{"@level":"error","@message":"CCC.C09: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612117-06:00"}
{"@level":"error","@message":"CCC.C10: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612143-06:00"}
{"@level":"error","@message":"CCC.C11: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612157-06:00"}
{"@level":"error","@message":"CCC.C11: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612172-06:00"}
{"@level":"error","@message":"CCC.C11: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612190-06:00"}
{"@level":"error","@message":"CCC.C11: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612206-06:00"}
{"@level":"error","@message":"CCC.VPC.C01: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612217-06:00"}
{"@level":"error","@message":"CCC.VPC.C02: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612228-06:00"}
{"@level":"error","@message":"CCC.VPC.C03: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612239-06:00"}
{"@level":"error","@message":"CCC.VPC.C04: testSet did not return a result, and may still be under development","@timestamp":"2025-01-20T13:44:52.612250-06:00"}
{"@level":"trace","@message":"Mobilization complete","@timestamp":"2025-01-20T13:44:52.612268-06:00"}
{"@level":"trace","@message":"Writing results","@timestamp":"2025-01-20T13:44:52.612514-06:00","filepath":"/Users/jmeridth/.privateer/logs/2025-01-20T134452-0600/my-cloud-service1/tlp_red.json"}
{"@level":"info","@message":"2025/01/20 13:44:52 tlp_red: 0/33 test sets succeeded","@timestamp":"2025-01-20T13:44:52.612781-06:00"}
```

</p>
</details> 