### PR TITLE
chore: revert ReadConfig function

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -32,9 +32,6 @@ func SetBase(cmd *cobra.Command) {
 	viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
 
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
-}
-
-func ReadConfig() {
 	viper.SetConfigFile(viper.GetString("config"))
 	viper.AutomaticEnv()
 
@@ -43,7 +40,6 @@ func ReadConfig() {
 	}
 }
 
-// defaultConfigPath returns the default config path
 func defaultConfigPath() string {
 	workDir, err := os.Getwd()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -87,14 +87,16 @@ func NewConfig(requiredVars []string) Config {
 	if serviceName == "" {
 		serviceName = "overview"
 	}
-	config.SetConfig(serviceName, false)
-	config.Logger.Trace(fmt.Sprintf("Creating a new config instance for service '%s'%v", serviceName, config))
-	config.Logger.Trace(fmt.Sprintf("loglevel: %s", loglevel))
-	config.Logger.Trace(fmt.Sprintf("write-directory: %v", invasive))
-	config.Logger.Trace(fmt.Sprintf("invasive: %v", writeDir))
-	config.Logger.Trace(fmt.Sprintf("test-suites: %v", testSuites))
-	config.Logger.Trace(fmt.Sprintf("vars: %v", vars))
-	config.Logger.Trace(fmt.Sprintf("writing output to file: %v", write))
+	config.SetupLogging(serviceName, false)
+	config.Logger.Trace("Creating a new config instance for service",
+		"serviceName", serviceName,
+		"loglevel", loglevel,
+		"write-directory", writeDir,
+		"invasive", invasive,
+		"test-suites", testSuites,
+		"vars", vars,
+		"writing output to file", write,
+	)
 	return config
 }
 
@@ -108,7 +110,7 @@ func defaultWritePath() string {
 	return filepath.Join(home, ".privateer", "logs", dirName)
 }
 
-func (c *Config) SetConfig(name string, jsonFormat bool) {
+func (c *Config) SetupLogging(name string, jsonFormat bool) {
 	var logFilePath string
 	logFile := name + ".log"
 	if name == "overview" {
@@ -122,8 +124,8 @@ func (c *Config) SetConfig(name string, jsonFormat bool) {
 	// Create log file and directory if it doesn't exist
 	if _, err := os.Stat(logFilePath); os.IsNotExist(err) {
 		// mkdir all directories from filepath
-		os.MkdirAll(path.Dir(logFilePath), os.ModePerm)
-		os.Create(logFilePath)
+		_ = os.MkdirAll(path.Dir(logFilePath), os.ModePerm)
+		_, _ = os.Create(logFilePath)
 	}
 
 	logFileObj, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)

--- a/pluginkit/vessel.go
+++ b/pluginkit/vessel.go
@@ -100,7 +100,10 @@ func (v *Vessel) Mobilize() (err error) {
 	for _, testSuite := range v.TestSuites {
 		err := testSuite.WriteTestSetResultsYAML(v.ServiceName)
 		if err != nil {
-			v.config.Logger.Error(fmt.Sprintf("Failed to write results for testSuite '%s': %v", testSuite.TestSuiteName, err))
+			v.config.Logger.Error("Failed to write results for testSuite",
+				"testSuite", testSuite.TestSuiteName,
+				"error", err,
+			)
 		}
 	}
 	return


### PR DESCRIPTION
- [x] replaced fmt logging with message, key/value pair logging format
- [x] revert ReadConfig function as it causes the log to not be read initially
- [x] fixed trace output of config (write directory and invasive were reversed)

I tested this inside the generated plugin and also from the core level.  Having the CORRECT config is the fix.  Not a code change.

Example new output of config trace:

### config.yml

```yaml
logLevel: trace
write-directory: test_output
services:
  my-cloud-services1:
    plugin: example
    test-suites:
      # - tlp_red
      # - tlp_amber
      - tlp_green
      - tlp_clear
```

### Service name NOT provided

```bash
➜  privateer git:(main) ✗ ./privateer run
2025-01-19T03:56:45.775-0600 [TRACE] Creating a new config instance for service: serviceName=overview loglevel=trace write-directory=/Users/jmeridth/.privateer/logs/2025-01-19T035645-0600 invasive=false test-suites=[] vars=map[] writing output to file=true
```

### Service name provided

```bash
➜  privateer git:(main) ✗ ./privateer run --service my-cloud-services1
2025-01-19T04:01:44.149-0600 [TRACE] Creating a new config instance for service: serviceName=my-cloud-services1 loglevel=trace write-directory=/Users/jmeridth/.privateer/logs/2025-01-19T040144-0600 invasive=false test-suites=["tlp_green", "tlp_clear"] vars=map[] writing output to file=true
```

Want to get this merged before I finish my work on #50 