### PR TITLE
fix: bad states not getting written to log

### DIFF
--- a/pluginkit/vessel.go
+++ b/pluginkit/vessel.go
@@ -100,10 +100,12 @@ func (v *Vessel) Mobilize() (err error) {
 		}
 
 		err = testSuite.Execute()
+
+		v.TestSuites = append(v.TestSuites, testSuite)
+
 		if testSuite.BadStateAlert {
 			break
 		}
-		v.TestSuites = append(v.TestSuites, testSuite)
 	}
 	v.config.Logger.Trace("Mobilization complete")
 


### PR DESCRIPTION
This PR ensures that bad states are recorded for logging in the same fashion as everything else.

After we merge this, I'd like to ask @sarahecraddock to confirm this resolves everything from #62.