### PR TITLE
fix: invasive config var will now prevent change.Apply() in plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
-	github.com/revanite-io/sci v0.1.8
+	github.com/revanite-io/sci v0.1.9
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/revanite-io/sci v0.1.8 h1:JmVHJu2TX42WlNEVtOufxmyCi8PYXEZmXfk2ClfYsnI=
-github.com/revanite-io/sci v0.1.8/go.mod h1:KNBMtb28TKYJ0aq6P0jX1XaIBYQdAziTvnI7uU2H+5Q=
+github.com/revanite-io/sci v0.1.9 h1:DnQ3NB1pqLhbRFYUM6CoA6hYbIJtRas1M6bJbsWL5VA=
+github.com/revanite-io/sci v0.1.9/go.mod h1:KNBMtb28TKYJ0aq6P0jX1XaIBYQdAziTvnI7uU2H+5Q=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -50,7 +50,7 @@ func (e *EvaluationSuite) Evaluate(name string) error {
 	e.Start_Time = time.Now().String()
 	e.config.Logger.Trace("Starting evaluation", "name", e.Name, "time", e.Start_Time)
 	for _, evaluation := range e.Control_Evaluations {
-		evaluation.Evaluate(e.payload, e.config.Policy.Applicability)
+		evaluation.Evaluate(e.payload, e.config.Policy.Applicability, e.config.Invasive)
 		evaluation.Cleanup()
 		if !e.Corrupted_State {
 			e.Corrupted_State = evaluation.Corrupted_State

--- a/pluginkit/test_data.go
+++ b/pluginkit/test_data.go
@@ -170,3 +170,144 @@ func step_Corrupted(_ interface{}, changes map[string]*layer4.Change) (result la
 	changes["corrupted-change"].Apply()
 	return layer4.Unknown, "This step always returns unknown and applies a corrupted change"
 }
+
+var mobilizeTestData = []testingData{
+	{
+		testName:       "Pass Evaluation",
+		expectedResult: layer4.Passed,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:       "Fail Evaluation",
+		expectedResult: layer4.Failed,
+		evals: []*layer4.ControlEvaluation{
+			failingEvaluation(),
+		},
+	},
+	{
+		testName:       "Needs Review Evaluation",
+		expectedResult: layer4.NeedsReview,
+		evals: []*layer4.ControlEvaluation{
+			needsReviewEvaluation(),
+		},
+	},
+	{
+		testName:           "Corrupted Evaluation",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			corruptedEvaluation(),
+		},
+	},
+	{
+		testName:       "Pass Pass Pass",
+		expectedResult: layer4.Passed,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			passingEvaluation(),
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:       "Pass Then Fail",
+		expectedResult: layer4.Failed,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			failingEvaluation(),
+		},
+	},
+	{
+		testName:       "Pass Then Needs Review",
+		expectedResult: layer4.NeedsReview,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			needsReviewEvaluation(),
+		},
+	},
+	{
+		testName:           "Pass Then Corrupted",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			corruptedEvaluation(),
+		},
+	},
+	{
+		testName:       "Needs Review Then Pass",
+		expectedResult: layer4.NeedsReview,
+		evals: []*layer4.ControlEvaluation{
+			needsReviewEvaluation(),
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:       "Needs Review Then Fail",
+		expectedResult: layer4.Failed,
+		evals: []*layer4.ControlEvaluation{
+			needsReviewEvaluation(),
+			failingEvaluation(),
+		},
+	},
+	{
+		testName:           "Corrupt Pass Pass",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			corruptedEvaluation(),
+			passingEvaluation(),
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:           "Pass Corrupt Pass",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			corruptedEvaluation(),
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:           "Pass Pass Corrupt",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			passingEvaluation(),
+			passingEvaluation(),
+			corruptedEvaluation(),
+		},
+	},
+	{
+		testName:           "Corrupt Corrupt Pass",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			corruptedEvaluation(),
+			corruptedEvaluation(),
+			passingEvaluation(),
+		},
+	},
+	{
+		testName:           "Corrupt Corrupt Corrupt",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			corruptedEvaluation(),
+			corruptedEvaluation(),
+			corruptedEvaluation(),
+		},
+	},
+	{
+		testName:           "Corrupt then Needs Review",
+		expectedResult:     layer4.Unknown,
+		expectedCorruption: true,
+		evals: []*layer4.ControlEvaluation{
+			corruptedEvaluation(),
+			needsReviewEvaluation(),
+		},
+	},
+}


### PR DESCRIPTION
Most of this work was done in the latest SCI release. This applies that upgrade and adds testing capability to ensure our execute function works properly when using the `invasive` config var.