### PR TITLE
chore: replace gopkg.in/yaml.v3 with github.com/goccy/go-yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,16 @@
 module github.com/privateerproj/privateer-sdk
 
 go 1.23.4
+
 toolchain go1.24.1
 
 require (
+	github.com/goccy/go-yaml v1.17.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/revanite-io/sci v0.3.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -38,6 +39,7 @@ require (
 	google.golang.org/grpc v1.67.3 // indirect
 	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // replace github.com/revanite-io/sci => ../../revanite-io/sci

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/revanite-io/sci/pkg/layer4"
-	"gopkg.in/yaml.v3"
 )
 
 type TestSet func() (result layer4.ControlEvaluation)

--- a/pluginkit/vessel.go
+++ b/pluginkit/vessel.go
@@ -7,9 +7,9 @@ import (
 	"path"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/revanite-io/sci/pkg/layer4"
-	"gopkg.in/yaml.v3"
 )
 
 // The vessel gets the armory in position to execute the ControlEvaluations specified in the testSuites


### PR DESCRIPTION
This change is being made as gopkg.in/yaml.v3 is no longer maintained.