### PR TITLE
chore: use gemara v0.3.10 in place of sci

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.23.4
 toolchain go1.24.1
 
 require (
-	github.com/goccy/go-yaml v1.17.1
+	github.com/goccy/go-yaml v1.18.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
-	github.com/revanite-io/sci v0.3.2
+	github.com/ossf/gemara v0.3.10
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 )
@@ -41,5 +41,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/revanite-io/sci => ../../revanite-io/sci

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
-github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -49,12 +49,12 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/ossf/gemara v0.3.10 h1:kweiPnzXEdKyrpl/XFcTn1BlVBHeKosW9TU/UFV6hJ4=
+github.com/ossf/gemara v0.3.10/go.mod h1:2EJVc3K4m0lLi0gGH0ptU43TCBv/EyeFYvDe9pG3Ryc=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/revanite-io/sci v0.3.2 h1:Rg0gUQZ4TF+hBXtqj3LF/zZH91jPJkUJooqQh3mqLm0=
-github.com/revanite-io/sci v0.3.2/go.mod h1:oF86d/9fyPH1ogfnYg9SvnpSYBzH1SVKhoxDGYOq5uk=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/ossf/gemara/layer4"
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/revanite-io/sci/pkg/layer4"
 )
 
 // The evaluation orchestrator gets the plugin in position to execute the specified evaluation suites

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ossf/gemara/layer4"
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/revanite-io/sci/pkg/layer4"
 )
 
 func TestSetPayload(t *testing.T) {

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/ossf/gemara/layer4"
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/revanite-io/sci/pkg/layer4"
 )
 
 type TestSet func() (result layer4.ControlEvaluation)
@@ -48,7 +48,7 @@ func (e *EvaluationSuite) Evaluate(name string) error {
 		evaluation.Evaluate(e.payload, e.config.Policy.Applicability, e.config.Invasive)
 		evaluation.Cleanup()
 		if !e.Corrupted_State {
-			e.Corrupted_State = evaluation.Corrupted_State
+			e.Corrupted_State = evaluation.CorruptedState
 		}
 
 		// Make sure the evaluation result is updated based on the complete assessment results
@@ -56,7 +56,7 @@ func (e *EvaluationSuite) Evaluate(name string) error {
 
 		// Log each assessment result as a separate line
 		for _, assessment := range evaluation.Assessments {
-			message := fmt.Sprintf("%s: %s", assessment.Requirement_Id, assessment.Message)
+			message := fmt.Sprintf("%s: %s", assessment.RequirementId, assessment.Message)
 			// switch case the code below
 			switch assessment.Result {
 			case layer4.Passed:
@@ -173,8 +173,8 @@ func (e *EvaluationSuite) writeControlEvaluationsToFile(serviceName string, resu
 func (e *EvaluationSuite) cleanup() (passed bool) {
 	for _, result := range e.Control_Evaluations {
 		result.Cleanup()
-		if result.Corrupted_State {
-			e.Corrupted_State = result.Corrupted_State
+		if result.CorruptedState {
+			e.Corrupted_State = result.CorruptedState
 		}
 	}
 	return !e.Corrupted_State

--- a/pluginkit/evaluation_suite_test.go
+++ b/pluginkit/evaluation_suite_test.go
@@ -3,7 +3,7 @@ package pluginkit
 import (
 	"testing"
 
-	"github.com/revanite-io/sci/pkg/layer4"
+	"github.com/ossf/gemara/layer4"
 )
 
 func TestCleanup(t *testing.T) {
@@ -31,10 +31,10 @@ func TestCleanup(t *testing.T) {
 			}
 			data.config = setBasicConfig()
 			for _, eval := range data.Control_Evaluations {
-				expectedCorrupted := eval.Corrupted_State
+				expectedCorrupted := eval.CorruptedState
 				eval.Cleanup()
-				if eval.Corrupted_State != expectedCorrupted {
-					t.Errorf("Expected control evaluation corruption to be %v, but got %v", expectedCorrupted, eval.Corrupted_State)
+				if eval.CorruptedState != expectedCorrupted {
+					t.Errorf("Expected control evaluation corruption to be %v, but got %v", expectedCorrupted, eval.CorruptedState)
 				}
 				result := data.cleanup()
 				if result == expectedCorrupted {
@@ -76,7 +76,7 @@ func TestEvaluate(t *testing.T) {
 				t.Errorf("Expected %s, but got %s", test.expectedEvalSuiteError, err)
 			}
 			for _, eval := range suite.Control_Evaluations {
-				if (eval.Result == layer4.Passed) && eval.Corrupted_State {
+				if (eval.Result == layer4.Passed) && eval.CorruptedState {
 					t.Errorf("Control evaluation was marked 'Passed' and Corrupted_State=true")
 				}
 				// TODO: test more of the evaluation suite behavior

--- a/pluginkit/test_data.go
+++ b/pluginkit/test_data.go
@@ -3,7 +3,7 @@ package pluginkit
 import (
 	"fmt"
 
-	"github.com/revanite-io/sci/pkg/layer4"
+	"github.com/ossf/gemara/layer4"
 	"github.com/spf13/viper"
 
 	"github.com/privateerproj/privateer-sdk/config"
@@ -25,7 +25,7 @@ func examplePayload(_ *config.Config) (interface{}, error) {
 
 func passingEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		Control_Id: "good-evaluation",
+		ControlID: "good-evaluation",
 	}
 
 	assessment := evaluation.AddAssessment(
@@ -53,7 +53,7 @@ func passingEvaluation() (evaluation *layer4.ControlEvaluation) {
 
 func failingEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		Control_Id: "bad-evaluation",
+		ControlID: "bad-evaluation",
 	}
 
 	evaluation.AddAssessment(
@@ -70,7 +70,7 @@ func failingEvaluation() (evaluation *layer4.ControlEvaluation) {
 
 func needsReviewEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		Control_Id: "needs-review-evaluation",
+		ControlID: "needs-review-evaluation",
 	}
 
 	evaluation.AddAssessment(
@@ -86,7 +86,7 @@ func needsReviewEvaluation() (evaluation *layer4.ControlEvaluation) {
 
 func corruptedEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		Control_Id: "corrupted-evaluation",
+		ControlID: "corrupted-evaluation",
 	}
 
 	assessment := evaluation.AddAssessment(


### PR DESCRIPTION
This PR updates our dependency to reflect the move of sci to the ossf and the rename to gemara