### PR TITLE
feat: renamed 'Vessel' struct to 'EvaluationOrchestrator'

### DIFF
--- a/command/plugin.go
+++ b/command/plugin.go
@@ -13,16 +13,16 @@ import (
 
 type Plugin struct{}
 
-var ActiveVessel *pluginkit.Vessel
+var ActiveEvaluationOrchestrator *pluginkit.EvaluationOrchestrator
 
 // Start will be called by Privateer via gRPC
 func (p *Plugin) Start() error {
-	return ActiveVessel.Mobilize()
+	return ActiveEvaluationOrchestrator.Mobilize()
 }
 
-func NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime string, vessel *pluginkit.Vessel) *cobra.Command {
+func NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime string, orchestrator *pluginkit.EvaluationOrchestrator) *cobra.Command {
 
-	ActiveVessel = vessel
+	ActiveEvaluationOrchestrator = orchestrator
 
 	runCmd := runCommand(pluginName)
 
@@ -60,7 +60,7 @@ func debugCommand() *cobra.Command {
 		Short: "Run the Plugin in debug mode",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Print("Running in debug mode\n")
-			err := ActiveVessel.Mobilize()
+			err := ActiveEvaluationOrchestrator.Mobilize()
 			if err != nil {
 				cmd.Println(err)
 			}

--- a/command/plugin_test.go
+++ b/command/plugin_test.go
@@ -20,9 +20,9 @@ func testingLoaderFunc(*config.Config) (interface{}, error) { return &nilInterfa
 
 func TestNewPluginCommands(t *testing.T) {
 	requiredVars := []string{}
-	vessel := pluginkit.NewVessel(pluginName, testingLoaderFunc, requiredVars)
+	orchestrator := pluginkit.NewEvaluationOrchestrator(pluginName, testingLoaderFunc, requiredVars)
 
-	cmd := NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime, vessel)
+	cmd := NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime, orchestrator)
 	if cmd.Use != pluginName {
 		t.Errorf("Expected cmd.Use to be %s, but got %s", pluginName, cmd.Use)
 	}

--- a/pluginkit/errors.go
+++ b/pluginkit/errors.go
@@ -24,6 +24,9 @@ var (
 	VESSEL_NAMES_NOT_SET = func(serviceName, pluginName string) error {
 		return fmt.Errorf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", serviceName, pluginName)
 	}
+	EVALUATION_ORCHESTRATOR_NAMES_NOT_SET = func(serviceName, pluginName string) error {
+		return fmt.Errorf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", serviceName, pluginName)
+	}
 	WRITE_FAILED = func(name, err string) error {
 		return fmt.Errorf("failed to write results for evaluation suite. name: %s, error: %s", name, err)
 	}

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -12,8 +12,8 @@ import (
 	"github.com/revanite-io/sci/pkg/layer4"
 )
 
-// The vessel gets the armory in position to execute the ControlEvaluations specified in the testSuites
-type Vessel struct {
+// The evaluation orchestrator gets the plugin in position to execute the specified evaluation suites
+type EvaluationOrchestrator struct {
 	Service_Name      string
 	Plugin_Name       string
 	Payload           interface{}
@@ -27,8 +27,8 @@ type Vessel struct {
 
 type DataLoader func(*config.Config) (interface{}, error)
 
-func NewVessel(pluginName string, loader DataLoader, requiredVars []string) *Vessel {
-	v := &Vessel{
+func NewEvaluationOrchestrator(pluginName string, loader DataLoader, requiredVars []string) *EvaluationOrchestrator {
+	v := &EvaluationOrchestrator{
 		Plugin_Name:  pluginName,
 		requiredVars: requiredVars,
 		loader:       loader,
@@ -36,7 +36,7 @@ func NewVessel(pluginName string, loader DataLoader, requiredVars []string) *Ves
 	return v
 }
 
-func (v *Vessel) AddEvaluationSuite(catalogId string, loader DataLoader, evaluations []*layer4.ControlEvaluation) {
+func (v *EvaluationOrchestrator) AddEvaluationSuite(catalogId string, loader DataLoader, evaluations []*layer4.ControlEvaluation) {
 	suite := EvaluationSuite{
 		Catalog_Id:          catalogId,
 		Control_Evaluations: evaluations,
@@ -50,7 +50,7 @@ func (v *Vessel) AddEvaluationSuite(catalogId string, loader DataLoader, evaluat
 	v.possibleSuites = append(v.possibleSuites, &suite)
 }
 
-func (v *Vessel) Mobilize() error {
+func (v *EvaluationOrchestrator) Mobilize() error {
 	v.setupConfig()
 	if v.config.Error != nil {
 		return v.config.Error
@@ -60,7 +60,7 @@ func (v *Vessel) Mobilize() error {
 		return BAD_LOADER(v.Plugin_Name, err)
 	}
 
-	v.config.Logger.Trace("Setting up vessel")
+	v.config.Logger.Trace("Setting up evaluation orchestrator")
 
 	if len(v.possibleSuites) == 0 {
 		return NO_EVALUATION_SUITES()
@@ -69,7 +69,7 @@ func (v *Vessel) Mobilize() error {
 	v.Service_Name = v.config.ServiceName
 
 	if v.Plugin_Name == "" || v.Service_Name == "" {
-		return VESSEL_NAMES_NOT_SET(v.Service_Name, v.Plugin_Name)
+		return EVALUATION_ORCHESTRATOR_NAMES_NOT_SET(v.Service_Name, v.Plugin_Name)
 	}
 
 	v.config.Logger.Trace("Mobilization beginning")
@@ -95,7 +95,7 @@ func (v *Vessel) Mobilize() error {
 	return v.WriteResults()
 }
 
-func (v *Vessel) WriteResults() error {
+func (v *EvaluationOrchestrator) WriteResults() error {
 
 	var err error
 	var result []byte
@@ -119,7 +119,7 @@ func (v *Vessel) WriteResults() error {
 	return nil
 }
 
-func (v *Vessel) writeResultsToFile(serviceName string, result []byte, extension string) error {
+func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result []byte, extension string) error {
 	if !strings.Contains(extension, ".") {
 		extension = fmt.Sprintf(".%s", extension)
 	}
@@ -163,7 +163,7 @@ func (v *Vessel) writeResultsToFile(serviceName string, result []byte, extension
 }
 
 // SetPayload allows the user to pass data to be referenced in assessments
-func (v *Vessel) loadPayload() (err error) {
+func (v *EvaluationOrchestrator) loadPayload() (err error) {
 	payload := new(interface{})
 	if v.loader != nil {
 		data, err := v.loader(v.config)
@@ -187,7 +187,7 @@ func (v *Vessel) loadPayload() (err error) {
 	return nil
 }
 
-func (v *Vessel) setupConfig() {
+func (v *EvaluationOrchestrator) setupConfig() {
 	if v.config == nil {
 		c := config.NewConfig(v.requiredVars)
 		v.config = &c

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -1,12 +1,5 @@
 package pluginkit
 
-// This file contains table tests for the following functions:
-// func (v *Vessel) SetInitilizer(initializer func(*config.Config) error) {
-// func (v *Vessel) SetPayload(payload interface{}) {
-// func (v *Vessel) Config() *config.Config {
-// func (v *Vessel) AddEvaluationSuite(name string, evaluations []layer4.ControlEvaluation) {
-// func (v *Vessel) Mobilize(requiredVars []string, suites map[string]EvaluationSuite) error {
-
 import (
 	"fmt"
 	"strings"
@@ -17,7 +10,7 @@ import (
 )
 
 func TestSetPayload(t *testing.T) {
-	v := NewVessel("test", nil, []string{})
+	v := NewEvaluationOrchestrator("test", nil, []string{})
 
 	payloadTestData := []struct {
 		name     string
@@ -53,7 +46,7 @@ func TestSetPayload(t *testing.T) {
 }
 
 func TestSetupConfig(t *testing.T) {
-	v := NewVessel("test", nil, []string{})
+	v := NewEvaluationOrchestrator("test", nil, []string{})
 	v.setupConfig()
 	if v.config == nil {
 		t.Error("Expected config to always be returned")
@@ -74,7 +67,7 @@ func TestAddEvaluationSuite(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			for _, suite := range test.evals {
 				t.Run("subtest_"+suite.Name, func(t *testing.T) {
-					v := NewVessel("test", nil, []string{})
+					v := NewEvaluationOrchestrator("test", nil, []string{})
 					v.config = setBasicConfig()
 					v.AddEvaluationSuite("test", nil, test.evals)
 					if len(v.possibleSuites) == 0 {
@@ -104,7 +97,7 @@ func TestMobilize(t *testing.T) {
 			var limitedConfigEvaluationCount int
 
 			tt.Run("limitedConfig", func(tt *testing.T) {
-				v := NewVessel("test", nil, []string{})
+				v := NewEvaluationOrchestrator("test", nil, []string{})
 				v.config = setLimitedConfig()
 
 				catalogName := strings.ReplaceAll(test.testName, " ", "-")
@@ -131,7 +124,7 @@ func TestMobilize(t *testing.T) {
 func runMobilizeTests(t *testing.T, test testingData, invasive bool, limitedConfigEvaluationCount int) {
 	catalogName := strings.ReplaceAll(test.testName, " ", "-")
 
-	v := NewVessel("test", nil, []string{})
+	v := NewEvaluationOrchestrator("test", nil, []string{})
 	v.config = setBasicConfig()
 	v.config.Invasive = invasive
 


### PR DESCRIPTION
This has been a long-standing technical debt since we renamed everything else away from "Fun" names, and this one was missed.