### PR TITLE
fix: ensure we're not persisting credentials after checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6.0.0
         with:
           go-version: "^1.23.4"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6.0.0
         with:
           go-version: stable


### PR DESCRIPTION
This PR adds security configuration to GitHub Actions workflows by setting persist-credentials: false for checkout actions. This prevents GitHub credentials from being persisted in the Git configuration after repository checkout, reducing potential security risks from credential exposure.

- Added persist-credentials: false to all actions/checkout@v5 steps across multiple workflow files
- Ensures credentials are not available to subsequent steps that don't explicitly need them
- Maintains existing workflow functionality while improving security posture