### PR TITLE
fix(ci): Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: []
     groups:
       dependencies:
         applies-to: version-updates
@@ -19,6 +20,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: []
     groups:
       dependencies:
         applies-to: version-updates


### PR DESCRIPTION
Update dependabot to not add labels to its PRs. It is colliding with our auto labeller and releases.