### PR TITLE
fix: logging of authn/credential vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,7 @@ func NewConfig(requiredVars []string) Config {
 		// Overwrite or add local vars onto the global vars
 		vars[key] = value
 	}
-	log.Printf("vars: %v", vars)
+	printSanitizedVars(vars)
 
 	topLoglevel := viper.GetString("loglevel")
 	loglevel := viper.GetString(fmt.Sprintf("services.%s.loglevel", serviceName))
@@ -140,6 +140,19 @@ func NewConfig(requiredVars []string) Config {
 		"output", output,
 	)
 	return config
+}
+
+func printSanitizedVars(vars map[string]interface{}) {
+	sanitizedVars := make(map[string]interface{})
+	for key, value := range vars {
+		switch key {
+		case "token", "auth", "password", "secret", "apikey", "api_key":
+			sanitizedVars[key] = "REDACTED"
+		default:
+			sanitizedVars[key] = value
+		}
+	}
+	log.Printf("Using vars: %v", sanitizedVars)
 }
 
 func defaultWritePath() string {


### PR DESCRIPTION
This commit sanitizes the vars during logging because vars used for authn creds are commonly provided

As an example, pvtr-github-repo, when run on the latest release, emits:

```
Using vars: map[owner:revanite-io repo:example-osps-baseline-level-1 token:gho_.......]
```

and, with this change, it will emit:

```
Using vars: map[owner:revanite-io repo:example-osps-baseline-level-1 token:REDACTED]
```