### PR TITLE
chore: get go version file for workflows from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6.0.0
         with:
-          go-version: "^1.23.4"
+          go-version-file: go.mod
 
       - name: Setup GO environment
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6.0.0
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:


### PR DESCRIPTION
Some items will fail if we do not use the version we use in go.mod this solution is the best in case we upgrade the version in go.mod again and forget to update the workflow or Dependabot misses it to.