### PR TITLE
chore: integrate with latest Gemara v0.11.0 layer4 schema changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goccy/go-yaml v1.18.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
-	github.com/ossf/gemara v0.10.1
+	github.com/ossf/gemara v0.11.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
 )
@@ -43,5 +43,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/ossf/gemara => ../../ossf/gemara

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/ossf/gemara v0.10.1 h1:rvM8s/dAqF0QkCtztwgx92o/hWukRdS4rzsTpRT9chY=
-github.com/ossf/gemara v0.10.1/go.mod h1:FRRem1gQ9m+c3QiBLN/PkL/RfzyNpF3aO7AWqZVzerg=
+github.com/ossf/gemara v0.11.0 h1:2C2SQBh5dvEXU5XPniaMg/SSkRch/gMB+oRBsmsJhQI=
+github.com/ossf/gemara v0.11.0/go.mod h1:FRRem1gQ9m+c3QiBLN/PkL/RfzyNpF3aO7AWqZVzerg=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pluginkit/errors.go
+++ b/pluginkit/errors.go
@@ -8,9 +8,6 @@ import (
 
 // Errors with no parameters
 var (
-	CORRUPTION_FOUND = func() error {
-		return errors.New("target state may be corrupted! Halting to prevent futher damage. See logs for more information")
-	}
 	NO_EVALUATION_SUITES = func() error {
 		return errors.New("no control evaluations provided by the plugin")
 	}

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -164,9 +164,6 @@ func runMobilizeTests(t *testing.T, test testingData, invasive bool, limitedConf
 			if test.expectedResult != suite.Result {
 				tt.Errorf("Expected result to be %v, but got %v", test.expectedResult, suite.Result)
 			}
-			if v.config.Invasive && suite.CorruptedState != test.expectedCorruption {
-				tt.Errorf("Expected corrupted state to be %v, but got %v", test.expectedCorruption, suite.CorruptedState)
-			}
 			evaluationSuiteName := fmt.Sprintf("%s_%s", v.ServiceName, catalogName)
 			if suite.Name != evaluationSuiteName {
 				tt.Errorf("Expected evaluation suite name to be %s, but got %s", evaluationSuiteName, suite.Name)

--- a/pluginkit/evaluation_suite_test.go
+++ b/pluginkit/evaluation_suite_test.go
@@ -6,48 +6,6 @@ import (
 	"github.com/ossf/gemara/layer4"
 )
 
-func TestCleanup(t *testing.T) {
-	testData := []testingData{
-		{
-			testName:       "Good Evaluation",
-			expectedResult: layer4.Passed,
-			evals: []*layer4.ControlEvaluation{
-				passingEvaluation(),
-			},
-		},
-		{
-			testName:       "Corrupted Evaluation",
-			expectedResult: layer4.Passed,
-			evals: []*layer4.ControlEvaluation{
-				corruptedEvaluation(),
-			},
-		},
-	}
-	for _, test := range testData {
-		t.Run(test.testName, func(t *testing.T) {
-			data := &EvaluationSuite{
-				Name:          test.testName,
-				EvaluationLog: layer4.EvaluationLog{Evaluations: test.evals},
-			}
-			data.config = setBasicConfig()
-			for _, eval := range data.EvaluationLog.Evaluations {
-				expectedCorrupted := eval.CorruptedState
-				eval.Cleanup()
-				if eval.CorruptedState != expectedCorrupted {
-					t.Errorf("Expected control evaluation corruption to be %v, but got %v", expectedCorrupted, eval.CorruptedState)
-				}
-				result := data.cleanup()
-				if result == expectedCorrupted {
-					t.Errorf("Expected cleanup to return %v, but got %v", expectedCorrupted, result)
-				}
-				if data.CorruptedState != expectedCorrupted {
-					t.Errorf("Expected suite result to be %v, but got %v", expectedCorrupted, data.Result)
-				}
-			}
-		})
-	}
-}
-
 func TestEvaluate(t *testing.T) {
 	testData := []testingData{
 		{
@@ -75,12 +33,9 @@ func TestEvaluate(t *testing.T) {
 			if err != nil && test.expectedEvalSuiteError != nil && err.Error() != test.expectedEvalSuiteError.Error() {
 				t.Errorf("Expected %s, but got %s", test.expectedEvalSuiteError, err)
 			}
-			for _, eval := range suite.EvaluationLog.Evaluations {
-				if (eval.Result == layer4.Passed) && eval.CorruptedState {
-					t.Errorf("Control evaluation was marked 'Passed' and CorruptedState=true")
-				}
-				// TODO: test more of the evaluation suite behavior
-			}
+			// TODO: test the evaluation suite behavior
+			// for _, eval := range suite.EvaluationLog.Evaluations {
+			// }
 		})
 	}
 }

--- a/pluginkit/test_data.go
+++ b/pluginkit/test_data.go
@@ -1,8 +1,6 @@
 package pluginkit
 
 import (
-	"fmt"
-
 	"github.com/ossf/gemara/layer4"
 	"github.com/spf13/viper"
 
@@ -13,7 +11,6 @@ type testingData struct {
 	testName               string
 	evals                  []*layer4.ControlEvaluation
 	expectedEvalSuiteError error
-	expectedCorruption     bool
 	expectedResult         layer4.Result
 }
 
@@ -25,10 +22,10 @@ func examplePayload(_ *config.Config) (interface{}, error) {
 
 func passingEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		ControlID: "good-evaluation",
+		ControlId: "good-evaluation",
 	}
 
-	assessment := evaluation.AddAssessment(
+	evaluation.AddAssessment(
 		"assessment-good",
 		"this assessment should work fine",
 		requestedApplicability,
@@ -36,24 +33,12 @@ func passingEvaluation() (evaluation *layer4.ControlEvaluation) {
 			step_Pass,
 		},
 	)
-	assessment.NewChange(
-		"good-change",
-		"fake-target-name",
-		"this change doesn't do anything",
-		nil,
-		func(interface{}) (interface{}, error) {
-			return nil, nil
-		},
-		func(interface{}) error {
-			return nil
-		},
-	)
 	return
 }
 
 func failingEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		ControlID: "bad-evaluation",
+		ControlId: "bad-evaluation",
 	}
 
 	evaluation.AddAssessment(
@@ -70,7 +55,7 @@ func failingEvaluation() (evaluation *layer4.ControlEvaluation) {
 
 func needsReviewEvaluation() (evaluation *layer4.ControlEvaluation) {
 	evaluation = &layer4.ControlEvaluation{
-		ControlID: "needs-review-evaluation",
+		ControlId: "needs-review-evaluation",
 	}
 
 	evaluation.AddAssessment(
@@ -79,34 +64,6 @@ func needsReviewEvaluation() (evaluation *layer4.ControlEvaluation) {
 		requestedApplicability,
 		[]layer4.AssessmentStep{
 			step_NeedsReview,
-		},
-	)
-	return
-}
-
-func corruptedEvaluation() (evaluation *layer4.ControlEvaluation) {
-	evaluation = &layer4.ControlEvaluation{
-		ControlID: "corrupted-evaluation",
-	}
-
-	assessment := evaluation.AddAssessment(
-		"assessment-corrupted",
-		"this assessment should be corrupted",
-		requestedApplicability,
-		[]layer4.AssessmentStep{
-			step_Corrupted,
-		},
-	)
-	assessment.NewChange(
-		"corrupted-change",
-		"fake-target-name",
-		"this change doesn't do anything",
-		nil,
-		func(interface{}) (interface{}, error) {
-			return nil, nil
-		},
-		func(interface{}) error {
-			return fmt.Errorf("corrupted")
 		},
 	)
 	return
@@ -135,24 +92,16 @@ type PayloadTypeExample struct {
 	CustomPayloadField bool
 }
 
-func step_Pass(data interface{}, changes map[string]*layer4.Change) (result layer4.Result, message string) {
-	if changes != nil && changes["good-change"] != nil {
-		changes["good-change"].Apply("target_name", "target_object", data)
-	}
+func step_Pass(data interface{}) (result layer4.Result, message string) {
 	return layer4.Passed, "This step always passes"
 }
 
-func step_Fail(_ interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func step_Fail(_ interface{}) (result layer4.Result, message string) {
 	return layer4.Failed, "This step always fails"
 }
 
-func step_NeedsReview(_ interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func step_NeedsReview(_ interface{}) (result layer4.Result, message string) {
 	return layer4.NeedsReview, "This step always needs review"
-}
-
-func step_Corrupted(data interface{}, changes map[string]*layer4.Change) (result layer4.Result, message string) {
-	changes["corrupted-change"].Apply("target_name", "target_object", data)
-	return layer4.Unknown, "This step always returns unknown and applies a corrupted change"
 }
 
 var mobilizeTestData = []testingData{
@@ -175,14 +124,6 @@ var mobilizeTestData = []testingData{
 		expectedResult: layer4.NeedsReview,
 		evals: []*layer4.ControlEvaluation{
 			needsReviewEvaluation(),
-		},
-	},
-	{
-		testName:           "Corrupted Evaluation",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			corruptedEvaluation(),
 		},
 	},
 	{
@@ -211,15 +152,6 @@ var mobilizeTestData = []testingData{
 		},
 	},
 	{
-		testName:           "Pass Then Corrupted",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			passingEvaluation(),
-			corruptedEvaluation(),
-		},
-	},
-	{
 		testName:       "Needs Review Then Pass",
 		expectedResult: layer4.NeedsReview,
 		evals: []*layer4.ControlEvaluation{
@@ -233,65 +165,6 @@ var mobilizeTestData = []testingData{
 		evals: []*layer4.ControlEvaluation{
 			needsReviewEvaluation(),
 			failingEvaluation(),
-		},
-	},
-	{
-		testName:           "Corrupt Pass Pass",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			corruptedEvaluation(),
-			passingEvaluation(),
-			passingEvaluation(),
-		},
-	},
-	{
-		testName:           "Pass Corrupt Pass",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			passingEvaluation(),
-			corruptedEvaluation(),
-			passingEvaluation(),
-		},
-	},
-	{
-		testName:           "Pass Pass Corrupt",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			passingEvaluation(),
-			passingEvaluation(),
-			corruptedEvaluation(),
-		},
-	},
-	{
-		testName:           "Corrupt Corrupt Pass",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			corruptedEvaluation(),
-			corruptedEvaluation(),
-			passingEvaluation(),
-		},
-	},
-	{
-		testName:           "Corrupt Corrupt Corrupt",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			corruptedEvaluation(),
-			corruptedEvaluation(),
-			corruptedEvaluation(),
-		},
-	},
-	{
-		testName:           "Corrupt then Needs Review",
-		expectedResult:     layer4.Unknown,
-		expectedCorruption: true,
-		evals: []*layer4.ControlEvaluation{
-			corruptedEvaluation(),
-			needsReviewEvaluation(),
 		},
 	},
 }


### PR DESCRIPTION
## Summary
Updates privateer-sdk to integrate with Gemara v0.11.0 layer4 schema changes that remove destructive changes management logic.

## Key Changes
- Update to Gemara v0.11.0 (official release)
- Remove `CorruptedState` field and corruption handling logic
- Update `ControlID` → `ControlId` for layer4 compatibility
- Remove `Changes` parameter from `AssessmentStep` functions
- Clean up test suite (removed corruption-related tests)


## Attribution
Based on initial work by @trumant in PR #120, updated to use official Gemara v0.11.0 release.

## Related
- References PR #120 by @trumant
- Implements Gemara PR ossf/gemara#151
- **Breaking change**: Aligns with upstream Gemara v0.11.0