### PR TITLE
fix: Set EvaluationLog metadata for SARIF tool name

### DIFF
--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -186,6 +186,14 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 				if err != nil {
 					v.config.Logger.Error(err.Error())
 				}
+				// Set plugin metadata in EvaluationLog for SARIF generation
+				suite.EvaluationLog.Metadata = layer4.Metadata{
+					Author: layer4.Author{
+						Name:    v.PluginName,
+						Uri:     v.PluginUri,
+						Version: v.PluginVersion,
+					},
+				}
 				v.Evaluation_Suites = append(v.Evaluation_Suites, suite)
 			}
 		}


### PR DESCRIPTION
## Problem

When generating SARIF output, the tool driver name was empty, causing GitHub Code Scanning API to reject uploads with the error:
```
Invalid request. 1 item required; only 0 were supplied
```

## Root Cause

The `EvaluationLog.Metadata.Author.Name` field was never populated, so when `ToSARIF()` tried to use it for the tool driver name, it resulted in an empty string. GitHub 

- Added code in `evaluation_orchestrator.go` to set `suite.EvaluationLog.Metadata` after evaluation completes
- Uses existing `PluginName`, `PluginUri`, and `PluginVersion` fields from the orchestrator
- Fixes SARIF upload failures for all plugins using the SDK
