### PR TITLE
fix: omit PhysicalLocation for repository-level assessments

### DIFF
--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -221,7 +221,7 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 		// Use empty string for artifactURI - repository-level assessments don't have specific file paths
 		// (empty string means no PhysicalLocation will be set in SARIF, avoiding URI scheme mismatch errors)
 		for _, suite := range v.Evaluation_Suites {
-			sarifBytes, sarifErr := suite.EvaluationLog.ToSARIF(artifactURI)
+			sarifBytes, sarifErr := suite.EvaluationLog.ToSARIF("")
 			if sarifErr != nil {
 				err = errMod(sarifErr, "wr25")
 				break


### PR DESCRIPTION
For repository-level assessments (like OSPS), we don't have specific file paths, so we should pass an empty artifactURI to omit PhysicalLocation. This fixes the 'SARIF URI scheme mismatch' error in GitHub Code Scanning that occurs when using PluginUri (https://) as artifactURI.