### PR TITLE
docs: add properly formatted godoc comments throughout

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -1,3 +1,4 @@
+// Package command provides command-line interface functionality for Privateer plugins.
 package command
 
 // Wontfix: Logging in this file has unexpected behavior related to the WriteDirectory and loglevel values.
@@ -11,7 +12,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// SetBase sets the base flags for all commands
+// SetBase sets the base flags for all commands.
 func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("config", "c", defaultConfigPath(), "Configuration File, JSON or YAML")
 	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
@@ -37,6 +38,7 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }
 
+// ReadConfig reads the configuration file specified in the config flag.
 func ReadConfig() {
 	viper.SetConfigFile(viper.GetString("config"))
 	viper.AutomaticEnv()

--- a/command/generate-plugin.go
+++ b/command/generate-plugin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
+// CatalogData extends layer2.Catalog with additional fields for plugin generation.
 type CatalogData struct {
 	layer2.Catalog
 	ServiceName             string
@@ -27,12 +28,13 @@ type CatalogData struct {
 	StrippedName            string
 }
 
+// Req represents an assessment requirement with an ID and text description.
 type Req struct {
 	Id   string
 	Text string
 }
 
-// GeneratePlugin generates a plugin from a catalog file
+// GeneratePlugin generates a plugin from a catalog file.
 func GeneratePlugin(logger hclog.Logger, templatesDir, sourcePath, outputDir, serviceName string) error {
 	data := CatalogData{}
 	data.ServiceName = serviceName
@@ -75,7 +77,7 @@ func GeneratePlugin(logger hclog.Logger, templatesDir, sourcePath, outputDir, se
 	return nil
 }
 
-// SetupTemplatingEnvironment validates and sets up the environment for plugin generation
+// SetupTemplatingEnvironment validates and sets up the environment for plugin generation.
 func SetupTemplatingEnvironment(logger hclog.Logger) (templatesDir, sourcePath, outputDir, serviceName string, err error) {
 	sourcePath = viper.GetString("source-path")
 	if sourcePath == "" {

--- a/command/list.go
+++ b/command/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Writer interface for output operations
+// Writer is an interface for output operations that supports writing and flushing.
 type Writer interface {
 	io.Writer
 	Flush() error
@@ -51,7 +51,7 @@ func GetListCmd(writer Writer) *cobra.Command {
 	return listCmd
 }
 
-// getRequestedPlugins returns a list of plugin names requested in the config
+// getRequestedPlugins returns a list of plugin names requested in the config.
 func getRequestedPlugins() (requestedPluginPackages []*PluginPkg) {
 	services := viper.GetStringMap("services")
 	for serviceName := range services {
@@ -63,7 +63,7 @@ func getRequestedPlugins() (requestedPluginPackages []*PluginPkg) {
 	return requestedPluginPackages
 }
 
-// getAvailablePlugins returns a list of plugins found in the binaries path
+// getAvailablePlugins returns a list of plugins found in the binaries path.
 func getAvailablePlugins() (availablePluginPackages []*PluginPkg) {
 	pluginPaths, _ := hcplugin.Discover("*", viper.GetString("binaries-path"))
 	for _, pluginPath := range pluginPaths {
@@ -79,7 +79,7 @@ func getAvailablePlugins() (availablePluginPackages []*PluginPkg) {
 
 var allPlugins []*PluginPkg
 
-// GetPlugins returns a combined list of all plugins (requested and available)
+// GetPlugins returns a combined list of all plugins (requested and available).
 func GetPlugins() []*PluginPkg {
 	if allPlugins != nil {
 		return allPlugins
@@ -99,7 +99,7 @@ func GetPlugins() []*PluginPkg {
 	return output
 }
 
-// Contains checks if a plugin with the given name exists in the slice
+// Contains checks if a plugin with the given name exists in the slice.
 func Contains(slice []*PluginPkg, search string) bool {
 	for _, plugin := range slice {
 		if plugin.Name == search {

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -11,15 +11,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Plugin represents a Privateer plugin instance.
 type Plugin struct{}
 
+// ActiveEvaluationOrchestrator is the currently active evaluation orchestrator.
 var ActiveEvaluationOrchestrator *pluginkit.EvaluationOrchestrator
 
-// Start will be called by Privateer via gRPC
+// Start will be called by Privateer via gRPC.
 func (p *Plugin) Start() error {
 	return ActiveEvaluationOrchestrator.Mobilize()
 }
 
+// NewPluginCommands creates a new cobra command for the plugin with version and orchestrator support.
 func NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime string, orchestrator *pluginkit.EvaluationOrchestrator) *cobra.Command {
 
 	ActiveEvaluationOrchestrator = orchestrator

--- a/command/run.go
+++ b/command/run.go
@@ -11,17 +11,17 @@ import (
 	"github.com/privateerproj/privateer-sdk/shared"
 )
 
-// Exit codes
+// Exit codes for plugin execution results.
 const (
-	TestPass = iota
-	TestFail
-	Aborted
-	InternalError
-	BadUsage
-	NoTests
+	TestPass      = iota // TestPass indicates all tests passed.
+	TestFail             // TestFail indicates one or more tests failed.
+	Aborted              // Aborted indicates execution was aborted.
+	InternalError        // InternalError indicates an internal error occurred.
+	BadUsage             // BadUsage indicates incorrect command usage.
+	NoTests              // NoTests indicates no tests were found to run.
 )
 
-// Run executes all plugins with handling for the command line
+// Run executes all plugins with handling for the command line.
 func Run(logger hclog.Logger, getPlugins func() []*PluginPkg) (exitCode int) {
 	logger.Trace(fmt.Sprintf(
 		"Using bin: %s", viper.GetString("binaries-path")))
@@ -89,9 +89,9 @@ func closeClient(pluginPkg *PluginPkg, serviceName string, client *hcplugin.Clie
 	client.Kill()
 }
 
-// newClient client handles the lifecycle of a plugin application
+// newClient handles the lifecycle of a plugin application.
 // Plugin hosts should use one Client for each plugin executable
-// (this is different from the client that manages gRPC)
+// (this is different from the client that manages gRPC).
 func newClient(cmd *exec.Cmd, logger hclog.Logger) *hcplugin.Client {
 	var pluginMap = map[string]hcplugin.Plugin{
 		shared.PluginName: &shared.Plugin{},

--- a/command/types.go
+++ b/command/types.go
@@ -11,14 +11,14 @@ import (
 	"github.com/spf13/viper"
 )
 
-// PluginError retains an error object and the name of the pack that generated it
+// PluginError retains an error object and the name of the pack that generated it.
 type PluginError struct {
 	Plugin string
 	Err    error
 }
 
 // PluginErrors holds a list of errors and an Error() method
-// so it adheres to the standard Error interface
+// so it adheres to the standard Error interface.
 type PluginErrors struct {
 	Errors []PluginError
 }
@@ -27,6 +27,7 @@ func (e *PluginErrors) Error() string {
 	return fmt.Sprintf("Service Pack Errors: %v", e.Errors)
 }
 
+// PluginPkg represents a plugin package with its metadata and execution state.
 type PluginPkg struct {
 	Name          string
 	Path          string
@@ -68,6 +69,7 @@ func (p *PluginPkg) queueCmd() {
 	}
 }
 
+// NewPluginPkg creates a new PluginPkg instance for the given plugin and service names.
 func NewPluginPkg(pluginName string, serviceName string) *PluginPkg {
 	plugin := &PluginPkg{
 		Name: pluginName,

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides configuration management for Privateer plugins.
 package config
 
 import (
@@ -18,6 +19,7 @@ import (
 
 var allowedOutputTypes = []string{"json", "yaml", "sarif"}
 
+// Config holds the configuration for a plugin execution.
 type Config struct {
 	ServiceName    string // Must be unique in the config file or logs will be overwritten
 	LogLevel       string
@@ -31,12 +33,14 @@ type Config struct {
 	Error          error
 }
 
+// Policy defines the control catalogs and applicability settings for a plugin.
+// TODO: We will want to replace this with a Gemara layer3 object now that those are ready.
 type Policy struct {
-	// TODO: We will want to replace this with a Gemara layer3 object now that those are ready
 	ControlCatalogs []string
 	Applicability   []string
 }
 
+// NewConfig creates a new Config instance from viper configuration.
 func NewConfig(requiredVars []string) Config {
 	var errString string
 
@@ -165,6 +169,7 @@ func defaultWritePath() string {
 	return filepath.Join(home, ".privateer", "logs", dirName)
 }
 
+// SetupLogging configures logging for the plugin with the given name and format.
 func (c *Config) SetupLogging(name string, jsonFormat bool) {
 	var logFilePath string
 	logFile := name + ".log"

--- a/pluginkit/errors.go
+++ b/pluginkit/errors.go
@@ -1,11 +1,13 @@
-// errors.go contains error definitions to streamline testing and log management
+// Package pluginkit provides the core plugin kit functionality for building Privateer plugins.
+//
+// This file contains error definitions to streamline testing and log management.
 package pluginkit
 
 import (
 	"fmt"
 )
 
-// Errors with no parameters
+// Error functions that require no parameters.
 var (
 	CORRUPTION_FOUND = func(mod string) error {
 		return errMod("target state may be corrupted! Halting to prevent futher damage. See logs for more information", mod)
@@ -30,7 +32,7 @@ var (
 	}
 )
 
-// Errors with parameters required
+// Error functions that require parameters.
 var (
 	EVALUATION_ORCHESTRATOR_NAMES_NOT_SET = func(serviceName, pluginName string, mod string) error {
 		return errMod(fmt.Errorf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", serviceName, pluginName), mod)

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -15,7 +15,7 @@ import (
 	"github.com/privateerproj/privateer-sdk/config"
 )
 
-// The evaluation orchestrator gets the plugin in position to execute the specified evaluation suites
+// EvaluationOrchestrator gets the plugin in position to execute the specified evaluation suites.
 type EvaluationOrchestrator struct {
 	ServiceName       string             `yaml:"service-name"`
 	PluginName        string             `yaml:"plugin-name"`
@@ -32,16 +32,20 @@ type EvaluationOrchestrator struct {
 	loader            DataLoader
 }
 
+// DataLoader is a function type for loading plugin data from configuration.
 type DataLoader func(*config.Config) (any, error)
 
+// AddLoader sets the data loader function for the orchestrator.
 func (v *EvaluationOrchestrator) AddLoader(loader DataLoader) {
 	v.loader = loader
 }
 
+// AddRequiredVars sets the required configuration variables for the orchestrator.
 func (v *EvaluationOrchestrator) AddRequiredVars(vars []string) {
 	v.requiredVars = vars
 }
 
+// AddReferenceCatalogs loads reference catalogs from the embedded file system.
 func (v *EvaluationOrchestrator) AddReferenceCatalogs(dataDir string, files embed.FS) error {
 	if v.referenceCatalogs == nil {
 		v.referenceCatalogs = make(map[string]*layer2.Catalog)
@@ -82,6 +86,7 @@ func (v *EvaluationOrchestrator) addPossibleControls(catalog *layer2.Catalog) {
 	}
 }
 
+// AddEvaluationSuite adds an evaluation suite for the given catalog ID.
 func (v *EvaluationOrchestrator) AddEvaluationSuite(catalogId string, loader DataLoader, steps map[string][]layer4.AssessmentStep) error {
 	if catalogId == "" {
 		return BAD_CATALOG(v.PluginName, "suite catalog id cannot be empty", "aos10")
@@ -119,7 +124,7 @@ func (v *EvaluationOrchestrator) addEvaluationSuite(catalog *layer2.Catalog, loa
 }
 
 // getImportedControlFamilies creates a new control family entry for each imported catalog
-// and only includes controls from the imported catalog that are listed in the imports of the primary catalog
+// and only includes controls from the imported catalog that are listed in the imports of the primary catalog.
 func getImportedControlFamilies(catalog *layer2.Catalog, referenceCatalogs map[string]*layer2.Catalog) (importedFamilies []layer2.ControlFamily) {
 	if len(catalog.ImportedControls) == 0 {
 		return importedFamilies
@@ -153,6 +158,7 @@ func getImportedControlFamilies(catalog *layer2.Catalog, referenceCatalogs map[s
 	return importedFamilies
 }
 
+// Mobilize initializes the orchestrator and executes all evaluation suites.
 func (v *EvaluationOrchestrator) Mobilize() error {
 	v.setupConfig()
 	if v.config.Error != nil {
@@ -206,6 +212,7 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 	return v.WriteResults()
 }
 
+// WriteResults writes the evaluation results to files in the configured output format.
 func (v *EvaluationOrchestrator) WriteResults() error {
 
 	var err error
@@ -287,7 +294,7 @@ func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result [
 	return nil
 }
 
-// SetPayload allows the user to pass data to be referenced in assessments
+// loadPayload loads the payload data to be referenced in assessments.
 func (v *EvaluationOrchestrator) loadPayload() (err error) {
 	payload := new(interface{})
 	if v.loader != nil {

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -9,10 +9,11 @@ import (
 	"github.com/privateerproj/privateer-sdk/config"
 )
 
+// TestSet is a function type that returns a control evaluation result.
 type TestSet func() (result layer4.ControlEvaluation)
 
-// EvaluationSuite is a struct that contains the results of all EvaluationLog executions
-// Exported fields will be used in the final YAML or JSON output documents
+// EvaluationSuite contains the results of all EvaluationLog executions.
+// Exported fields will be used in the final YAML or JSON output documents.
 type EvaluationSuite struct {
 	Name   string        // Name is the name of the suite
 	Result layer4.Result // Result is Passed if all evaluations in the suite passed
@@ -38,7 +39,7 @@ type EvaluationSuite struct {
 	evalWarnings  int // warnings is the number of evaluations that need review
 }
 
-// AddChangeManager sets up the change manager for the evaluation suite
+// AddChangeManager sets up the change manager for the evaluation suite.
 func (e *EvaluationSuite) AddChangeManager(cm *ChangeManager) {
 	if e.config.Invasive && cm != nil {
 		e.changeManager = cm
@@ -46,8 +47,8 @@ func (e *EvaluationSuite) AddChangeManager(cm *ChangeManager) {
 	}
 }
 
-// Execute is used to execute a list of EvaluationLog provided by a Plugin and customized by user config
-// Name is an arbitrary string that will be used to identify the EvaluationSuite
+// Evaluate executes a list of EvaluationLog provided by a Plugin and customized by user config.
+// Name is an arbitrary string that will be used to identify the EvaluationSuite.
 func (e *EvaluationSuite) Evaluate(serviceName string) error {
 	if e.config == nil {
 		return CONFIG_NOT_INITIALIZED("ev10")
@@ -133,6 +134,7 @@ func (e *EvaluationSuite) Evaluate(serviceName string) error {
 	return nil
 }
 
+// GetAssessmentRequirements retrieves all assessment requirements from the catalog.
 func (e *EvaluationSuite) GetAssessmentRequirements() (map[string]*layer2.AssessmentRequirement, error) {
 	requirements := make(map[string]*layer2.AssessmentRequirement)
 	for _, family := range e.catalog.ControlFamilies {

--- a/pluginkit/get_plugin_catalogs.go
+++ b/pluginkit/get_plugin_catalogs.go
@@ -14,9 +14,9 @@ import (
 // Then we just need some parent object that contains map of catalogs by Id
 // and figure out where we need to pass that around
 
-// GetPluginCatalog reads all YAML catalog files in the data directory and returns the complete catalog data
-// This is necessary when packaging the catalog files into a binary, which is not supported by the Gemara loader
-// If a catalog imports another, both should be in the same directory
+// getPluginCatalogs reads all YAML catalog files in the data directory and returns the complete catalog data.
+// This is necessary when packaging the catalog files into a binary, which is not supported by the Gemara loader.
+// If a catalog imports another, both should be in the same directory.
 func getPluginCatalogs(dataDir string, files embed.FS) (catalogs []*layer2.Catalog, err error) {
 	dir, err := files.ReadDir(dataDir)
 	// Check if files are in the right place
@@ -37,7 +37,7 @@ func getPluginCatalogs(dataDir string, files embed.FS) (catalogs []*layer2.Catal
 	return catalogs, nil // just returns the last catalog for now
 }
 
-// ReadYAMLFile reads a single YAML file and returns the control family data
+// readYAMLFile reads a single YAML file and returns the control family data.
 func readYAMLFile(filePath string, files embed.FS) (*layer2.Catalog, error) {
 	data, err := files.ReadFile(filePath)
 	if err != nil {

--- a/sdk.go
+++ b/sdk.go
@@ -1,1 +1,2 @@
+// Package sdk provides the core SDK for building Privateer plugins.
 package sdk

--- a/shared/plugin.go
+++ b/shared/plugin.go
@@ -1,3 +1,4 @@
+// Package shared provides shared functionality for Privateer plugins.
 package shared
 
 import (
@@ -6,54 +7,54 @@ import (
 	hcplugin "github.com/hashicorp/go-plugin"
 )
 
-// Plugin is the interface that we're exposing as a plugin.
+// Pluginer is the interface that we're exposing as a plugin.
 type Pluginer interface {
 	Start() error
 }
 
-// PluginRPC is an implementation that talks over RPC
+// PluginRPC is an implementation that talks over RPC.
 type PluginRPC struct{ client *rpc.Client }
 
-// Start is a wrapper for interface implementation of Start
+// Start is a wrapper for interface implementation of Start.
 func (g *PluginRPC) Start() error {
 	var err error
 	return g.client.Call("Plugin.Start", new(interface{}), &err)
 }
 
 // PluginRPCServer is the RPC server that PluginRPC talks to, conforming to
-// the requirements of net/rpc
+// the requirements of net/rpc.
 type PluginRPCServer struct {
-	// This is the real implementation
+	// Impl is the real implementation.
 	Impl Pluginer
 }
 
-// Start is a wrapper for interface implementation
+// Start is a wrapper for interface implementation.
 func (s *PluginRPCServer) Start(args interface{}, resp *error) error {
 	*resp = s.Impl.Start()
 	return *resp
 }
 
-// Plugin is the implementation of plugin.Plugin so we can serve/consume this
+// Plugin is the implementation of plugin.Plugin so we can serve/consume this.
 //
 // This has two methods: Server must return an RPC server for this plugin
-// type. We construct a GreeterRPCServer for this.
+// type. We construct a PluginRPCServer for this.
 //
 // Client must return an implementation of our interface that communicates
-// over an RPC client. We return GreeterRPC for this.
+// over an RPC client. We return PluginRPC for this.
 //
 // Ignore MuxBroker. That is used to create more multiplexed streams on our
 // plugin connection and is a more advanced use case.
 type Plugin struct {
-	// Impl Injection
+	// Impl is the plugin implementation.
 	Impl Pluginer
 }
 
-// Server implements RPC server
+// Server implements RPC server.
 func (p *Plugin) Server(*hcplugin.MuxBroker) (interface{}, error) {
 	return &PluginRPCServer{Impl: p.Impl}, nil
 }
 
-// Client implements RPC client
+// Client implements RPC client.
 func (Plugin) Client(b *hcplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return &PluginRPC{client: c}, nil
 }

--- a/shared/serve.go
+++ b/shared/serve.go
@@ -7,10 +7,10 @@ import (
 	hcplugin "github.com/hashicorp/go-plugin"
 )
 
-// PluginName overwritten to be used by Privateer Core sally.go: rpcClient.Dispense(plugin.PluginName)
+// PluginName is used by Privateer Core sally.go: rpcClient.Dispense(plugin.PluginName).
 const PluginName = "plugin"
 
-// handshakeConfigs are used to just do a basic handshake between
+// handshakeConfig is used to just do a basic handshake between
 // a hcplugin and host. If the handshake fails, a user friendly error is shown.
 // This prevents users from executing bad hcplugins or executing a hcplugin
 // directly. It is a UX feature, not a security feature.
@@ -18,7 +18,7 @@ var handshakeConfig = GetHandshakeConfig()
 
 // ServeOpts are the configurations to serve a plugin.
 type ServeOpts struct {
-	//Interface implementation
+	// Plugin is the interface implementation.
 	Plugin Pluginer
 
 	// Logger is the logger that go-plugin will use.
@@ -46,7 +46,8 @@ func Serve(pluginName string, opts *ServeOpts) {
 	log.Printf("Successfully completed plugin: %s", pluginName)
 }
 
-// GetHandshakeConfig provides handshake config details. It is used by core and service packs.
+// GetHandshakeConfig provides handshake config details.
+// It is used by core and service packs.
 func GetHandshakeConfig() hcplugin.HandshakeConfig {
 	return hcplugin.HandshakeConfig{
 		ProtocolVersion:  1,

--- a/utils/random.go
+++ b/utils/random.go
@@ -13,10 +13,10 @@ const (
 	letterIdxMax    = 63 / letterIndexBits   // # of letter indices fitting in 63 bits
 )
 
-// src is a global variable that generates a new seed for the random number generator
+// src is a global variable that generates a new seed for the random number generator.
 var src = rand.NewSource(time.Now().UnixNano())
 
-// RandomString generates a pseudo-random number of characters of length n
+// RandomString generates a pseudo-random string of characters of length n.
 func RandomString(n int) string {
 	bytes := make([]byte, n)
 	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,4 +1,5 @@
-// Package utils provides general utility methods.  The '*Ptr' functions were borrowed/inspired by the kubernetes go-client.
+// Package utils provides general utility methods.
+// The '*Ptr' functions were borrowed/inspired by the kubernetes go-client.
 package utils
 
 import (
@@ -14,7 +15,7 @@ import (
 func init() {
 }
 
-// BoolPtr returns a pointer to a bool
+// BoolPtr returns a pointer to a bool.
 func BoolPtr(b bool) *bool {
 	return &b
 }
@@ -24,19 +25,19 @@ func StringPtr(s string) *string {
 	return &s
 }
 
-// Int64Ptr returns a pointer to an int64
+// Int64Ptr returns a pointer to an int64.
 func Int64Ptr(i int64) *int64 {
 	return &i
 }
 
-// JSON marshals a struct into JSON with indentation
+// JSON marshals a struct into JSON with indentation.
 func JSON(data interface{}) []byte {
 	j, _ := json.MarshalIndent(data, "", "  ")
 	return []byte(j)
 }
 
 // FindString searches a []string for a specific value.
-// If found, returns the index of first occurrence, and True. If not found, returns -1 and False.
+// If found, returns the index of first occurrence, and true. If not found, returns -1 and false.
 func FindString(slice []string, val string) (int, bool) {
 	for i, item := range slice {
 		if item == val {
@@ -46,32 +47,32 @@ func FindString(slice []string, val string) (int, bool) {
 	return -1, false
 }
 
-// CallerName retrieves the name of the function prior to the location it is called
-// If using CallerName(0), the current function's name will be returned
-// If using CallerName(1), the current function's parent name will be returned
-// If using CallerName(2), the current function's parent's parent name will be returned
+// CallerName retrieves the name of the function prior to the location it is called.
+// If using CallerName(0), the current function's name will be returned.
+// If using CallerName(1), the current function's parent name will be returned.
+// If using CallerName(2), the current function's parent's parent name will be returned.
 func CallerName(up int) string {
 	s := strings.Split(CallerPath(up+1), ".") // split full caller path
 	return s[len(s)-1]                        // select last element from caller path
 }
 
 // CallerPath checks the goroutine's stack of function invocation and returns the following:
-// For up=0, return full caller path for caller function
-// For up=1, returns full caller path for caller of caller
+// For up=0, return full caller path for caller function.
+// For up=1, returns full caller path for caller of caller.
 func CallerPath(up int) string {
 	f := make([]uintptr, 1)
 	runtime.Callers(up+2, f)                  // add full caller path to empty object
 	return runtime.FuncForPC(f[0] - 1).Name() // get full caller path in string form
 }
 
-// CallerFileLine returns file name and line of invoker
-// Similar to CallerName(1), but with file and line returned
+// CallerFileLine returns file name and line of invoker.
+// Similar to CallerName(1), but with file and line returned.
 func CallerFileLine() (string, int) {
 	_, file, line, _ := runtime.Caller(2)
 	return file, line
 }
 
-// ReformatError prefixes the error string ready for logging and/or output
+// ReformatError prefixes the error string ready for logging and/or output.
 func ReformatError(e string, v ...interface{}) error {
 	var b strings.Builder
 	b.WriteString("[ERROR] ")
@@ -80,19 +81,19 @@ func ReformatError(e string, v ...interface{}) error {
 	return fmt.Errorf(b.String(), v...)
 }
 
-// ReplaceBytesValue replaces a substring with a new value for a given string in bytes
+// ReplaceBytesValue replaces a substring with a new value for a given string in bytes.
 func ReplaceBytesValue(b []byte, old string, new string) []byte {
 	newString := strings.ReplaceAll(string(b), old, new)
 	return []byte(newString)
 }
 
-// ReplaceBytesMultipleValues replaces multiple substring with a new value for a given string in bytes
+// ReplaceBytesMultipleValues replaces multiple substrings with a new value for a given string in bytes.
 func ReplaceBytesMultipleValues(b []byte, replacer *strings.Replacer) []byte {
 	newString := replacer.Replace(string(b))
 	return []byte(newString)
 }
 
-// WriteAllowed determines whether a given filepath can be written to
+// WriteAllowed determines whether a given filepath can be written to.
 func WriteAllowed(path string) error {
 	_, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
 	if os.IsPermission(err) {
@@ -104,7 +105,7 @@ func WriteAllowed(path string) error {
 	return nil
 }
 
-// GetExecutableName returns name of executable without file extension
+// GetExecutableName returns name of executable without file extension.
 func GetExecutableName() string {
 	execAbsPath, err := os.Executable()
 	if err != nil {
@@ -121,6 +122,7 @@ func GetExecutableName() string {
 	return execName
 }
 
+// StringSliceContains checks if a string value exists in a string slice.
 func StringSliceContains(arr []string, val string) bool {
 	for _, a := range arr {
 		if a == val {


### PR DESCRIPTION
- Add package-level godoc comments to all packages
- Update all exported types, functions, constants, and variables with proper godoc formatting
- Ensure all comments start with the exported name and use complete sentences
- Follow Go godoc conventions for consistency across the codebase