### PR TITLE
fix: redirect plugin log output to stderr for go-plugin compatibility

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -102,6 +103,8 @@ func newClient(cmd *exec.Cmd, logger hclog.Logger) *hcplugin.Client {
 		Plugins:         pluginMap,
 		Cmd:             cmd,
 		Logger:          logger,
+		SyncStdout:      os.Stdout,
+		SyncStderr:      os.Stderr,
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -181,7 +181,7 @@ func (c *Config) SetupLogging(name string, jsonFormat bool) {
 		logFilePath = path.Join(c.WriteDirectory, name, logFile)
 	}
 
-	writer := io.Writer(os.Stdout)
+	writer := io.Writer(os.Stderr)
 	if c.Write {
 		writer = c.setupLoggingFilesAndDirectories(logFilePath)
 	}
@@ -209,6 +209,6 @@ func (c *Config) setupLoggingFilesAndDirectories(logFilePath string) io.Writer {
 		log.Panic(err) // TODO: handle this error better
 	}
 
-	writer := io.MultiWriter(logFileObj, os.Stdout)
+	writer := io.MultiWriter(logFileObj, os.Stderr)
 	return writer
 }


### PR DESCRIPTION
Closes https://github.com/privateerproj/privateer/issues/98

## What

Redirect plugin subprocess log output from stdout to stderr and set SyncStdout/SyncStderr on the go-plugin ClientConfig to forward any remaining non-protocol output from plugin subprocesses.

## Why

HashiCorp's go-plugin framework reserves the plugin's stdout for its RPC handshake protocol. Plugin logs written to stdout were being consumed by go-plugin and silently discarded (SyncStdout defaults to io.Discard). This caused all runtime logs to be suppressed when plugins were executed through privateer, even with --loglevel=trace.

## Notes

Plugins writing to stderr is the go-plugin convention — go-plugin reads stderr line by line and forwards it through the host's logger, which means the host logger's level will also filter the output. The SyncStdout/SyncStderr on ClientConfig is a safety net for any non-hclog output a plugin might produce.