### PR TITLE
feat: add security insights configuration and validation workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# All PRs in this repository will be blocked
-# until they have been approved by a maintainer
-
 * @privateerproj/oss

--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,0 +1,62 @@
+header:
+  schema-version: 2.2.0
+  last-updated: "2026-02-21"
+  last-reviewed: "2026-02-21"
+  url: https://github.com/privateerproj/privateer-sdk/blob/main/.github/security-insights.yml
+  project-si-source: https://raw.githubusercontent.com/privateerproj/.github/refs/heads/main/.github/security-insights.yml
+  comment: |
+    This file contains only the repository information for the Privateer SDK.
+
+repository:
+  url: https://github.com/privateerproj/privateer-sdk
+  status: active
+  bug-fixes-only: false
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Eddie Knight
+      affiliation: Sonatype
+      social: https://bsky.app/profile/eddieknight.dev
+      primary: true
+    - name: Jason Meridth
+      affiliation: Chainguard
+      social: https://github.com/jmeridth
+      primary: false
+  documentation:
+    contributing-guide: https://github.com/privateerproj/.github/blob/main/.github/CONTRIBUTING.md
+    security-policy: https://github.com/privateerproj/.github/blob/main/.github/SECURITY.md
+  license:
+    url: https://github.com/privateerproj/privateer-sdk?tab=Apache-2.0-1-ov-file#readme
+    expression: Apache-2.0
+  release:
+    changelog: https://github.com/privateerproj/privateer-sdk/releases
+    automated-pipeline: true
+    distribution-points:
+      - uri: https://github.com/privateerproj/privateer-sdk/releases
+        comment: GitHub Release Page
+  security:
+    assessments:
+      self:
+        comment: |
+          A self assessment has not been published for this repo.
+    champions:
+      - name: Jason Meridth
+        primary: true
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: "2"
+        rulesets:
+          - default
+        results:
+          adhoc:
+            name: Scheduled SCA Scan Results
+            predicate-uri: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
+            location: https://github.com/privateerproj/privateer-sdk/security/dependabot
+            comment: |
+              The results of the scheduled SCA scan are available in the Dependabot tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: false
+          release: false

--- a/.github/workflows/security-insights.yml
+++ b/.github/workflows/security-insights.yml
@@ -1,0 +1,30 @@
+---
+name: Validate Security Insights
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/security-insights.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/security-insights.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Security Insights
+        uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2
+        with:
+          file: .github/security-insights.yml


### PR DESCRIPTION
## What

Add OSPS Security Insights v2.2.0 specification file and a GitHub Actions workflow to validate it on push and PR to main.

## Why

Aligns this repository with the security transparency practices already established in the core privateer repo, providing machine-readable security metadata per the OSPS specification.

## Notes

- The CODEOWNERS file was also simplified — the explanatory comments were removed, leaving only the ownership rule.
- The validation action is pinned to a specific SHA (85c35a5) rather than a mutable tag.