### PR TITLE
feat: add octo-sts trust policy for privateer-sdk

### DIFF
--- a/.github/chainguard/privateer-sdk.sts.yaml
+++ b/.github/chainguard/privateer-sdk.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:privateerproj/privateer-sdk:(pull_request|ref:refs/heads/.+)"
+claim_pattern:
+  job_workflow_ref: "^privateerproj/privateer-sdk/.github/workflows/osps-security-assessment.yml@refs/(heads/.+|pull/[0-9]+/merge)$"
+
+permissions:
+  contents: read
+  statuses: read
+  deployments: read
+  security_events: read
+  administration: read


### PR DESCRIPTION
## What

Add an octo-sts OIDC trust policy that allows the osps-security-assessment workflow to exchange GitHub Actions tokens for scoped, short-lived tokens.

## Why

This trust policy is a prerequisite for switching the OSPS assessment workflow from long-lived PATs to octo-sts token federation. It must be merged to the default branch before the dependent workflow changes can authenticate.

## Notes

- The subject_pattern permits both pull_request and branch push events.
- The claim_pattern restricts token exchange to only the osps-security-assessment workflow.