### PR TITLE
fix: add id-token: write permissions to osps workflow

### DIFF
--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
       security-events: write # Required for SARIF upload
 
     steps:


### PR DESCRIPTION
needed for use with octo-sts temporary tokens