### PR TITLE
fix: remove raw vars from config trace log to prevent token leak

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,7 +142,6 @@ func NewConfig(requiredVars []string) Config {
 		"invasive", invasive,
 		"applicability", applicability,
 		"control-catalogs", catalogs,
-		"vars", vars,
 		"output", output,
 	)
 	return config
@@ -158,7 +157,7 @@ func printSanitizedVars(logger hclog.Logger, vars map[string]interface{}) {
 			sanitizedVars[key] = value
 		}
 	}
-	logger.Trace("Using vars: %v", sanitizedVars)
+	logger.Trace("Using vars", "vars", sanitizedVars)
 }
 
 func defaultWritePath() string {


### PR DESCRIPTION
## Summary

`NewConfig` was logging the raw `vars` map as a Trace field directly after calling `printSanitizedVars`. That meant any sensitive value — token, password, API key — in `vars` was emitted to the log in plaintext regardless of the sanitization helper running above it.

This removes the raw `"vars", vars` field from the Trace call so only the redacted output from `printSanitizedVars` is logged. A secondary fix switches `printSanitizedVars` from printf-style to proper structured `hclog` key/value logging.