### PR TITLE
chore: upgrade go to 1.26.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
         with:
-          version: v2.4.0
+          version: v2.11.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/privateerproj/privateer-sdk
 
-go 1.25.1
+go 1.26.2
 
 require (
 	github.com/gemaraproj/go-gemara v0.0.2


### PR DESCRIPTION
## What

Upgrade Go from 1.25.1 to 1.26.2 in go.mod and bump golangci-lint from v2.4.0 to v2.11.4.

## Why

go1.26.2 fixes 4 vulnerabilities in the standard library:

- GO-2026-4947: unexpected work during chain building (crypto/x509)
- GO-2026-4946: inefficient policy validation (crypto/x509)
- GO-2026-4870: unauthenticated TLS 1.3 KeyUpdate DoS (crypto/tls)
- GO-2026-4866: case-sensitive excludedSubtrees auth bypass (crypto/x509)

## Notes

- This is a two-minor-version jump (1.25 → 1.26); all tests pass
- golangci-lint v2.4.0 was built with Go 1.25 and cannot lint Go 1.26 code, so bumped to v2.11.4