### PR TITLE
fix: allow generate-plugin --source-path to accept URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __debug_bin
 # Test
 coverage.out
 **/tmp
+
+# Claude Code
+**/.claude/*.local.*

--- a/command/generate-plugin.go
+++ b/command/generate-plugin.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"text/template"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/go-git/go-git/v5"
 	hclog "github.com/hashicorp/go-hclog"
@@ -50,7 +51,12 @@ func GeneratePlugin(logger hclog.Logger, cfg PluginConfig) error {
 	data.ServiceName = cfg.ServiceName
 	data.Organization = cfg.Organization
 
-	err := data.LoadFile("file://" + cfg.SourcePath)
+	sourcePath, err := resolveSourcePath(cfg.SourcePath)
+	if err != nil {
+		return fmt.Errorf("invalid source path: %w", err)
+	}
+
+	err = data.LoadFile(sourcePath)
 	if err != nil {
 		return err
 	}
@@ -258,6 +264,25 @@ func snakeCase(in string) string {
 	return strings.TrimSpace(
 		strings.ReplaceAll(
 			strings.ReplaceAll(in, ".", "_"), "-", "_"))
+}
+
+// resolveSourcePath ensures the source path has an appropriate URI scheme.
+// URLs with https:// are passed through as-is; bare file paths get file:// prepended.
+func resolveSourcePath(sourcePath string) (string, error) {
+	parsed, err := url.Parse(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "https", "file":
+		return sourcePath, nil
+	case "http":
+		return "", fmt.Errorf("http URLs are not supported, use https")
+	case "":
+		return "file://" + sourcePath, nil
+	default:
+		return "", fmt.Errorf("unsupported scheme: %s", parsed.Scheme)
+	}
 }
 
 func copyNonTemplateFile(templatePath, relativeFilepath, outputDir string, logger hclog.Logger) error {

--- a/command/generate-plugin_test.go
+++ b/command/generate-plugin_test.go
@@ -1,0 +1,63 @@
+package command
+
+import (
+	"testing"
+)
+
+func TestResolveSourcePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "bare file path gets file:// prepended",
+			input:    "/path/to/catalog.yaml",
+			expected: "file:///path/to/catalog.yaml",
+		},
+		{
+			name:     "relative file path gets file:// prepended",
+			input:    "catalog.yaml",
+			expected: "file://catalog.yaml",
+		},
+		{
+			name:     "https URL passed through",
+			input:    "https://example.com/catalog.yaml",
+			expected: "https://example.com/catalog.yaml",
+		},
+		{
+			name:     "file:// URL passed through",
+			input:    "file:///path/to/catalog.yaml",
+			expected: "file:///path/to/catalog.yaml",
+		},
+		{
+			name:      "http URL rejected",
+			input:     "http://example.com/catalog.yaml",
+			expectErr: true,
+		},
+		{
+			name:      "unsupported scheme rejected",
+			input:     "ftp://example.com/catalog.yaml",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := resolveSourcePath(tc.input)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil, result: %s", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The --source-path argument for generate-plugin now correctly handles https:// URLs
in addition to local file paths.

## Why

The previous implementation unconditionally prepended "file://" to the source path,
which broke URL inputs despite the go-gemara library already supporting https:// sources.

## Notes

- Rejects http:// (insecure) and unknown schemes explicitly rather than letting them
  fail opaquely downstream
- The go-gemara v0.0.2 LoadYAML/LoadJSON already handle https fetching internally,
  so no new HTTP logic was needed in the SDK
- Added **/.claude/*.local.* to .gitignore

## Testing

- Table-driven unit tests for resolveSourcePath covering: bare file paths, relative
  paths, https URLs, file:// URLs, rejected http://, and rejected unknown schemes
- Full test suite passes (`go test ./...`)