### PR TITLE
fix: replace stream copy with placeholder replacement for non-template files

### DIFF
--- a/command/generate-plugin.go
+++ b/command/generate-plugin.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -164,9 +163,9 @@ func generateFileFromTemplate(data CatalogData, templatePath, templatesDir, outp
 		return fmt.Errorf("error calculating relative path for %s: %w", templatePath, err)
 	}
 
-	// If the file is not a template, copy it over as-is (preserve mode)
+	// If the file is not a template, copy it over with placeholder replacement
 	if filepath.Ext(templatePath) != ".tmpl" {
-		return copyNonTemplateFile(templatePath, relativeFilepath, outputDir, logger)
+		return copyNonTemplateFile(data, templatePath, relativeFilepath, outputDir, logger)
 	}
 
 	tmpl, err := template.New("plugin").Funcs(template.FuncMap{
@@ -282,39 +281,29 @@ func resolveSourcePath(sourcePath string) (string, error) {
 	return sourcePath, nil
 }
 
-func copyNonTemplateFile(templatePath, relativeFilepath, outputDir string, logger hclog.Logger) error {
+func copyNonTemplateFile(data CatalogData, templatePath, relativeFilepath, outputDir string, logger hclog.Logger) error {
 	outputPath := filepath.Join(outputDir, relativeFilepath)
 	if err := os.MkdirAll(filepath.Dir(outputPath), os.ModePerm); err != nil {
 		return fmt.Errorf("error creating directories for %s: %w", outputPath, err)
 	}
 
-	// Copy file contents
-	srcFile, err := os.Open(templatePath)
+	content, err := os.ReadFile(templatePath)
 	if err != nil {
-		return fmt.Errorf("error opening source file %s: %w", templatePath, err)
+		return fmt.Errorf("error reading source file %s: %w", templatePath, err)
 	}
-	defer func() {
-		err := srcFile.Close()
-		if err != nil {
-			logger.Error("error closing output file %s: %w", templatePath, err)
-		}
-	}()
 
-	dstFile, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("error creating destination file %s: %w", outputPath, err)
-	}
-	defer func() {
-		_ = dstFile.Close()
-	}()
-
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		return fmt.Errorf("error copying file to %s: %w", outputPath, err)
-	}
+	// Replace placeholders in non-template files
+	output := strings.ReplaceAll(string(content), "__SERVICE_NAME__", data.ServiceName)
+	output = strings.ReplaceAll(output, "__ORGANIZATION__", data.Organization)
 
 	// Try to preserve file mode from source
+	mode := os.FileMode(0644)
 	if fi, err := os.Stat(templatePath); err == nil {
-		_ = os.Chmod(outputPath, fi.Mode())
+		mode = fi.Mode()
+	}
+
+	if err := os.WriteFile(outputPath, []byte(output), mode); err != nil {
+		return fmt.Errorf("error writing file %s: %w", outputPath, err)
 	}
 
 	return nil

--- a/command/generate-plugin_test.go
+++ b/command/generate-plugin_test.go
@@ -1,7 +1,11 @@
 package command
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
 )
 
 func TestResolveSourcePath(t *testing.T) {
@@ -52,5 +56,107 @@ func TestResolveSourcePath(t *testing.T) {
 				t.Errorf("expected %s, got %s", tc.expected, result)
 			}
 		})
+	}
+}
+
+func TestCopyNonTemplateFile(t *testing.T) {
+	logger := hclog.NewNullLogger()
+
+	tests := []struct {
+		name            string
+		inputContent    string
+		serviceName     string
+		organization    string
+		expectedContent string
+	}{
+		{
+			name:            "replaces SERVICE_NAME and ORGANIZATION placeholders",
+			inputContent:    "name: __SERVICE_NAME__\norg: __ORGANIZATION__\n",
+			serviceName:     "my-plugin",
+			organization:    "my-org",
+			expectedContent: "name: my-plugin\norg: my-org\n",
+		},
+		{
+			name:            "no placeholders passes through unchanged",
+			inputContent:    "version: 2\nbefore:\n  hooks:\n    - go mod tidy\n",
+			serviceName:     "my-plugin",
+			organization:    "my-org",
+			expectedContent: "version: 2\nbefore:\n  hooks:\n    - go mod tidy\n",
+		},
+		{
+			name:            "multiple occurrences of same placeholder all replaced",
+			inputContent:    "a: __SERVICE_NAME__\nb: __SERVICE_NAME__\nc: __ORGANIZATION__\nd: __ORGANIZATION__\n",
+			serviceName:     "svc",
+			organization:    "org",
+			expectedContent: "a: svc\nb: svc\nc: org\nd: org\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			outDir := t.TempDir()
+
+			srcPath := filepath.Join(srcDir, "testfile.yaml")
+			if err := os.WriteFile(srcPath, []byte(tc.inputContent), 0644); err != nil {
+				t.Fatalf("failed to write source file: %v", err)
+			}
+
+			data := CatalogData{
+				ServiceName:  tc.serviceName,
+				Organization: tc.organization,
+			}
+
+			err := copyNonTemplateFile(data, srcPath, "testfile.yaml", outDir, logger)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, err := os.ReadFile(filepath.Join(outDir, "testfile.yaml"))
+			if err != nil {
+				t.Fatalf("failed to read output file: %v", err)
+			}
+
+			if string(got) != tc.expectedContent {
+				t.Errorf("expected %q, got %q", tc.expectedContent, string(got))
+			}
+		})
+	}
+}
+
+func TestCopyNonTemplateFilePreservesMode(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	srcDir := t.TempDir()
+	outDir := t.TempDir()
+
+	srcPath := filepath.Join(srcDir, "script.sh")
+	if err := os.WriteFile(srcPath, []byte("#!/bin/bash\n"), 0755); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	data := CatalogData{ServiceName: "svc", Organization: "org"}
+	err := copyNonTemplateFile(data, srcPath, "script.sh", outDir, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fi, err := os.Stat(filepath.Join(outDir, "script.sh"))
+	if err != nil {
+		t.Fatalf("failed to stat output file: %v", err)
+	}
+
+	if fi.Mode().Perm() != 0755 {
+		t.Errorf("expected mode 0755, got %o", fi.Mode().Perm())
+	}
+}
+
+func TestCopyNonTemplateFileMissingSource(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	outDir := t.TempDir()
+
+	data := CatalogData{ServiceName: "svc", Organization: "org"}
+	err := copyNonTemplateFile(data, "/nonexistent/file.yaml", "file.yaml", outDir, logger)
+	if err == nil {
+		t.Fatal("expected error for missing source file, got nil")
 	}
 }


### PR DESCRIPTION
## What

Non-template files copied during plugin generation now have `__SERVICE_NAME__` and `__ORGANIZATION__` placeholders replaced with actual values from the catalog data. The stream-based copy was replaced with a read-replace-write approach and the unused `io` import was removed.

## Why

The .goreleaser template in plugin-generator-templates uses goreleaser's own template syntax (e.g. `{{ title .Os }}`) which conflicts with Go's `text/template` parser. By switching non-template files to placeholder-based substitution, files with their own template syntax can coexist without escaping gymnastics.

## Notes

- Companion change in privateerproj/plugin-generator-templates renames `.goreleaser.tmpl` to `.goreleaser.yaml` with `__SERVICE_NAME__` placeholder
- The `logger` parameter on `copyNonTemplateFile` is now unused but retained for signature consistency
- Any non-template file in the templates repo can now use `__SERVICE_NAME__` and `__ORGANIZATION__` placeholders

## Testing

- All existing unit tests pass (`go test ./...`)
- Lint clean (`golangci-lint run ./...`)