### PR TITLE
fix: use substring matching for sensitive key redaction in printSanitizedVars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -148,16 +148,29 @@ func NewConfig(requiredVars []string) Config {
 }
 
 func printSanitizedVars(logger hclog.Logger, vars map[string]interface{}) {
+	sanitizedVars := sanitizeVars(vars)
+	logger.Trace("Using vars", "vars", sanitizedVars)
+}
+
+func sanitizeVars(vars map[string]interface{}) map[string]interface{} {
+	sensitivePatterns := []string{"token", "auth", "password", "secret", "apikey", "api_key"}
 	sanitizedVars := make(map[string]interface{})
 	for key, value := range vars {
-		switch key {
-		case "token", "auth", "password", "secret", "apikey", "api_key":
+		redact := false
+		lower := strings.ToLower(key)
+		for _, pattern := range sensitivePatterns {
+			if strings.Contains(lower, pattern) {
+				redact = true
+				break
+			}
+		}
+		if redact {
 			sanitizedVars[key] = "REDACTED"
-		default:
+		} else {
 			sanitizedVars[key] = value
 		}
 	}
-	logger.Trace("Using vars", "vars", sanitizedVars)
+	return sanitizedVars
 }
 
 func defaultWritePath() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -515,6 +515,47 @@ func TestPrintSanitizedVars(t *testing.T) {
 	printSanitizedVars(logger, vars)
 }
 
+func TestSanitizeVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		expected string
+	}{
+		// Exact matches (existing behavior)
+		{"exact token", "token", "val", "REDACTED"},
+		{"exact auth", "auth", "val", "REDACTED"},
+		{"exact password", "password", "val", "REDACTED"},
+		{"exact secret", "secret", "val", "REDACTED"},
+		{"exact apikey", "apikey", "val", "REDACTED"},
+		{"exact api_key", "api_key", "val", "REDACTED"},
+
+		// Compound keys (new behavior)
+		{"compound clientsecret", "clientsecret", "val", "REDACTED"},
+		{"compound authtoken", "authtoken", "val", "REDACTED"},
+		{"compound apikey_v2", "apikey_v2", "val", "REDACTED"},
+		{"compound my_api_key", "my_api_key", "val", "REDACTED"},
+		{"compound AccessToken", "AccessToken", "val", "REDACTED"},
+		{"compound ClientSecret", "ClientSecret", "val", "REDACTED"},
+		{"compound PASSWORD_HASH", "PASSWORD_HASH", "val", "REDACTED"},
+
+		// Non-sensitive keys should not be redacted
+		{"safe username", "username", "val", "val"},
+		{"safe region", "region", "val", "val"},
+		{"safe endpoint", "endpoint", "val", "val"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := map[string]interface{}{tc.key: tc.value}
+			result := sanitizeVars(vars)
+			if result[tc.key] != tc.expected {
+				t.Errorf("sanitizeVars(%q) = %q, want %q", tc.key, result[tc.key], tc.expected)
+			}
+		})
+	}
+}
+
 func TestSetupLogging(t *testing.T) {
 	c := Config{
 		WriteDirectory: "/tmp/test",


### PR DESCRIPTION
Fixes https://github.com/privateerproj/privateer-sdk/issues/197

## What

Replace exact switch/case matching with case-insensitive substring matching for sensitive config var key redaction. Extract sanitizeVars into its own function for testability.

## Why

Plugin authors use compound key names like `clientsecret`, `authtoken`, and `apikey_v2` that contain sensitive substrings but were logged in plaintext at Trace level because the match was exact rather than substring-based.

## Notes

- Keys containing "auth" will now be redacted, which could mask non-sensitive keys like "author" or "authorization_type" — worth monitoring if this causes confusion in trace logs
- The existing `printSanitizedVars` test was a no-op (null logger, no assertions) — preserved as-is, new assertions are in `TestSanitizeVars`

## Testing

- Added table-driven `TestSanitizeVars` covering exact matches (existing behavior), compound keys (new behavior), and non-sensitive keys
- Full test suite passes (`go test ./...`)