### PR TITLE
fix: restrict directory permissions from 0777 to 0750

### DIFF
--- a/command/generate-plugin.go
+++ b/command/generate-plugin.go
@@ -127,7 +127,7 @@ func SetupTemplatingEnvironment(logger hclog.Logger) (PluginConfig, error) {
 	cfg.OutputDir = viper.GetString("output-dir")
 	logger.Trace(fmt.Sprintf("Generated plugin will be stored in this directory: %s", cfg.OutputDir))
 
-	err := os.MkdirAll(cfg.OutputDir, os.ModePerm)
+	err := os.MkdirAll(cfg.OutputDir, utils.DirPermissions)
 	if err != nil {
 		return cfg, err
 	}
@@ -187,7 +187,7 @@ func generateFileFromTemplate(data CatalogData, templatePath, templatesDir, outp
 
 	outputPath := filepath.Join(outputDir, strings.TrimSuffix(relativeFilepath, ".tmpl"))
 
-	err = os.MkdirAll(filepath.Dir(outputPath), os.ModePerm)
+	err = os.MkdirAll(filepath.Dir(outputPath), utils.DirPermissions)
 	if err != nil {
 		return fmt.Errorf("error creating directories for %s: %w", outputPath, err)
 	}
@@ -249,7 +249,7 @@ func writeCatalogFile(catalog *gemara.ControlCatalog, outputDir string) error {
 	fileName := fmt.Sprintf("catalog_%s_%s.yaml", id, version)
 	filePath := filepath.Join(dirPath, fileName)
 
-	err = os.MkdirAll(dirPath, os.ModePerm)
+	err = os.MkdirAll(dirPath, utils.DirPermissions)
 	if err != nil {
 		return fmt.Errorf("error creating directories for %s: %w", filePath, err)
 	}
@@ -283,7 +283,7 @@ func resolveSourcePath(sourcePath string) (string, error) {
 
 func copyNonTemplateFile(data CatalogData, templatePath, relativeFilepath, outputDir string, logger hclog.Logger) error {
 	outputPath := filepath.Join(outputDir, relativeFilepath)
-	if err := os.MkdirAll(filepath.Dir(outputPath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outputPath), utils.DirPermissions); err != nil {
 		return fmt.Errorf("error creating directories for %s: %w", outputPath, err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/privateerproj/privateer-sdk/utils"
 	"github.com/spf13/viper"
 )
 
@@ -213,7 +214,7 @@ func (c *Config) setupLoggingFilesAndDirectories(logFilePath string) io.Writer {
 	// Create log file and directory if it doesn't exist
 	if _, err := os.Stat(logFilePath); os.IsNotExist(err) {
 		// mkdir all directories from filepath
-		_ = os.MkdirAll(path.Dir(logFilePath), os.ModePerm)
+		_ = os.MkdirAll(path.Dir(logFilePath), utils.DirPermissions)
 		_, _ = os.Create(logFilePath)
 	}
 

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gemaraproj/go-gemara/gemaraconv"
 	"github.com/goccy/go-yaml"
 	"github.com/privateerproj/privateer-sdk/config"
+	"github.com/privateerproj/privateer-sdk/utils"
 )
 
 // EvaluationOrchestrator gets the plugin in position to execute the specified evaluation suites.
@@ -289,7 +290,7 @@ func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result [
 
 	// Create log file and directory if it doesn't exist
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, os.ModePerm)
+		err = os.MkdirAll(dir, utils.DirPermissions)
 		if err != nil {
 			v.config.Logger.Error("Error creating directory", "directory", dir)
 			return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 )
 
+// DirPermissions is the default permission mode for directories created by the SDK.
+// 0750 = owner: rwx, group: r-x, others: --- (no access).
+const DirPermissions os.FileMode = 0750
+
 func init() {
 }
 


### PR DESCRIPTION
## Summary

Replace all `os.ModePerm` (0777) directory creation calls with a shared `utils.DirPermissions` constant set to `0750` (owner: rwx, group: r-x, others: no access).

Previously, directories for plugin output, logs, evaluation results, and generated plugin code were created world-writable. On shared systems (CI runners, multi-tenant containers), this allowed any user to read, modify, or inject content into these directories. Restricting to `0750` follows the principle of least privilege.

## Limitations

- No existing tests assert on directory permission bits. The change is a straightforward constant swap and all existing tests pass.
- On systems where another process (running as a different user/group) previously relied on the `0777` permissions to access output directories, this will restrict that access. This is the intended security improvement.