### PR TITLE
fix: namespace viper env overrides with PVTR_ prefix

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,6 +42,10 @@ func SetBase(cmd *cobra.Command) {
 // ReadConfig reads the configuration file. If --config is explicitly provided,
 // that exact path is used. Otherwise, it searches ./config.yml and ~/.privateer/config.yml.
 func ReadConfig() {
+	// Namespace env overrides so only PVTR_* vars are recognized,
+	// preventing accidental or malicious collisions on shared systems.
+	viper.SetEnvPrefix("PVTR")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	configPath := viper.GetString("config")

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -208,3 +208,30 @@ func TestReadConfig_CwdTakesPrecedenceOverHome(t *testing.T) {
 		t.Errorf("expected loglevel 'debug' from cwd config, got %q", viper.GetString("loglevel"))
 	}
 }
+
+func TestReadConfig_UnprefixedEnvIgnored(t *testing.T) {
+	resetViper()
+	t.Setenv("LOGLEVEL", "trace")
+	ReadConfig()
+	if viper.GetString("loglevel") == "trace" {
+		t.Error("unprefixed env var should not override config")
+	}
+}
+
+func TestReadConfig_PrefixedEnvOverrides(t *testing.T) {
+	resetViper()
+	t.Setenv("PVTR_LOGLEVEL", "debug")
+	ReadConfig()
+	if viper.GetString("loglevel") != "debug" {
+		t.Errorf("expected 'debug', got %q", viper.GetString("loglevel"))
+	}
+}
+
+func TestReadConfig_HyphenatedKeyViaUnderscoredEnv(t *testing.T) {
+	resetViper()
+	t.Setenv("PVTR_WRITE_DIRECTORY", "/tmp/test-output")
+	ReadConfig()
+	if viper.GetString("write-directory") != "/tmp/test-output" {
+		t.Errorf("expected '/tmp/test-output', got %q", viper.GetString("write-directory"))
+	}
+}


### PR DESCRIPTION
## Summary

Add `viper.SetEnvPrefix("PVTR")` and `viper.SetEnvKeyReplacer` to `ReadConfig()` so that only `PVTR_`-prefixed environment variables can override config keys.

Previously, `viper.AutomaticEnv()` allowed *any* environment variable matching a config key name (e.g., `CONFIG`, `WRITE_DIRECTORY`, `LOGLEVEL`) to override settings. On shared CI runners or multi-tenant containers, a malicious co-tenant could set env vars to redirect plugin discovery, output paths, or config sources.

The `SetEnvKeyReplacer` maps hyphens in config keys to underscores in env var names, so `write-directory` resolves to `PVTR_WRITE_DIRECTORY`.

## Breaking Changes

Environment variable overrides now require a `PVTR_` prefix. Migration examples:

| Before | After |
|--------|-------|
| `LOGLEVEL=debug` | `PVTR_LOGLEVEL=debug` |
| `WRITE_DIRECTORY=/tmp` | `PVTR_WRITE_DIRECTORY=/tmp` |
| `CONFIG=/path/to/config.yml` | `PVTR_CONFIG=/path/to/config.yml` |

CLI flags (`--loglevel`, `--write-directory`, etc.) and config file values are unaffected.

## Limitations

- `PVTR_REGISTRY_URL` in `internal/registry/client.go` is read via `os.Getenv()` directly, not through viper. It continues to work unchanged but is not managed through the same config system. Unifying this is a follow-up improvement.