### PR TITLE
fix: replace insecure random number generation and unsafe pointer use

### DIFF
--- a/utils/random.go
+++ b/utils/random.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"math/rand"
-	"time"
-	"unsafe"
+	"math/rand/v2"
 )
 
 const (
@@ -13,24 +11,19 @@ const (
 	letterIdxMax    = 63 / letterIndexBits   // # of letter indices fitting in 63 bits
 )
 
-// src is a global variable that generates a new seed for the random number generator.
-var src = rand.NewSource(time.Now().UnixNano())
-
-// RandomString generates a pseudo-random string of characters of length n.
+// RandomString generates a pseudo-random string of lowercase characters of length n.
 func RandomString(n int) string {
-	bytes := make([]byte, n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+	b := make([]byte, n)
+	for i, cache, remain := n-1, rand.Int64(), letterIdxMax; i >= 0; {
 		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
+			cache, remain = rand.Int64(), letterIdxMax
 		}
 		if idx := int(cache & letterIdxMask); idx < len(letters) {
-			bytes[i] = letters[idx]
+			b[i] = letters[idx]
 			i--
 		}
 		cache >>= letterIndexBits
 		remain--
 	}
-
-	return *(*string)(unsafe.Pointer(&bytes))
+	return string(b)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -161,3 +161,21 @@ func TestGetExecutableName(t *testing.T) {
 		})
 	}
 }
+
+func TestRandomString_Length(t *testing.T) {
+	for _, n := range []int{0, 1, 5, 20, 100} {
+		s := RandomString(n)
+		if len(s) != n {
+			t.Errorf("RandomString(%d) returned length %d", n, len(s))
+		}
+	}
+}
+
+func TestRandomString_OnlyLowercaseLetters(t *testing.T) {
+	s := RandomString(1000)
+	for i, c := range s {
+		if c < 'a' || c > 'z' {
+			t.Errorf("RandomString produced non-lowercase char %q at index %d", c, i)
+		}
+	}
+}


### PR DESCRIPTION
`RandomString` used a time-seeded `math/rand` source, making its output predictable, and converted the result using `unsafe.Pointer`, which bypasses Go's memory safety guarantees. This replaces both with `math/rand/v2` (auto-seeded from a cryptographic source) and a safe `string(b)` conversion. Adds unit tests for output length and character set correctness.