### PR TITLE
feat: send exit codes from plugin runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ test-cov:
 	@echo "Running tests and generating coverage output"
 	@go test ./... -coverprofile coverage.out -covermode count
 	@echo "Current test coverage : $(shell go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+') %"
+
+bench:
+	@echo "  >  Running benchmarks ..."
+	go test -bench=. -benchmem -run=^$$ ./...

--- a/command/install.go
+++ b/command/install.go
@@ -19,7 +19,9 @@ import (
 var validNameSegment = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // GetInstallCmd returns the install command that can be added to a root command.
-func GetInstallCmd(writer Writer) *cobra.Command {
+// writerFn is called at command execution time, so the writer can be
+// initialized lazily (e.g. in a PersistentPreRun hook).
+func GetInstallCmd(writerFn func() Writer) *cobra.Command {
 	var localPath string
 
 	installCmd := &cobra.Command{
@@ -28,6 +30,7 @@ func GetInstallCmd(writer Writer) *cobra.Command {
 		Long:  "Install a vetted plugin from the registry, or use --local to install a plugin binary from a local path.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			writer := writerFn()
 			if localPath != "" {
 				return installLocal(writer, localPath)
 			}

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -18,8 +18,9 @@ type Plugin struct{}
 var ActiveEvaluationOrchestrator *pluginkit.EvaluationOrchestrator
 
 // Start will be called by Privateer via gRPC.
-func (p *Plugin) Start() error {
-	return ActiveEvaluationOrchestrator.Mobilize()
+func (p *Plugin) Start() (int, error) {
+	err := ActiveEvaluationOrchestrator.Mobilize()
+	return pluginkit.ExitCodeFor(ActiveEvaluationOrchestrator, err), err
 }
 
 // NewPluginCommands creates a new cobra command for the plugin with version and orchestrator support.

--- a/command/run.go
+++ b/command/run.go
@@ -12,15 +12,31 @@ import (
 	"github.com/privateerproj/privateer-sdk/shared"
 )
 
-// Exit codes for plugin execution results.
+// Aliases for the canonical values in shared/ — kept here so command.TestPass
+// etc. stay valid for existing callers.
 const (
-	TestPass      = iota // TestPass indicates all tests passed.
-	TestFail             // TestFail indicates one or more tests failed.
-	Aborted              // Aborted indicates execution was aborted.
-	InternalError        // InternalError indicates an internal error occurred.
-	BadUsage             // BadUsage indicates incorrect command usage.
-	NoTests              // NoTests indicates no tests were found to run.
+	TestPass      = shared.TestPass
+	TestFail      = shared.TestFail
+	Aborted       = shared.Aborted
+	InternalError = shared.InternalError
+	BadUsage      = shared.BadUsage
+	NoTests       = shared.NoTests
 )
+
+// Across multi-plugin runs the most severe outcome wins.
+var exitSeverity = map[int]int{
+	TestPass:      0,
+	TestFail:      1,
+	BadUsage:      2,
+	InternalError: 3,
+}
+
+func mergeExitCode(prev, next int) int {
+	if exitSeverity[next] > exitSeverity[prev] {
+		return next
+	}
+	return prev
+}
 
 // Run executes all plugins with handling for the command line.
 func Run(logger hclog.Logger, getPlugins func() []*PluginPkg) (exitCode int) {
@@ -64,12 +80,13 @@ func Run(logger hclog.Logger, getPlugins func() []*PluginPkg) (exitCode int) {
 				// Execute plugin
 				plugin := rawPlugin.(shared.Pluginer)
 				logger.Trace(fmt.Sprintf("Starting Plugin %v: %s", runCount, pluginPkg.Name))
-				response := plugin.Start()
+				pluginExitCode, response := plugin.Start()
 				if response != nil {
-					pluginPkg.Error = fmt.Errorf("tests failed in plugin %s: %v", serviceName, response)
-					exitCode = TestFail
-				} else {
-					pluginPkg.Successful = true
+					pluginPkg.Error = fmt.Errorf("plugin %s: %v", serviceName, response)
+				}
+				pluginPkg.Successful = pluginExitCode == TestPass
+				if !pluginPkg.Successful {
+					exitCode = mergeExitCode(exitCode, pluginExitCode)
 				}
 				pluginPkg.closeClient(serviceName, client, logger)
 			}

--- a/command/run_test.go
+++ b/command/run_test.go
@@ -1,0 +1,28 @@
+package command
+
+import "testing"
+
+func TestMergeExitCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		prev, next int
+		want       int
+	}{
+		{"TestPass over TestPass keeps TestPass", TestPass, TestPass, TestPass},
+		{"TestFail beats TestPass", TestPass, TestFail, TestFail},
+		{"TestPass after TestFail keeps TestFail", TestFail, TestPass, TestFail},
+		{"BadUsage beats TestFail", TestFail, BadUsage, BadUsage},
+		{"TestFail does not downgrade BadUsage", BadUsage, TestFail, BadUsage},
+		{"InternalError beats BadUsage", BadUsage, InternalError, InternalError},
+		{"BadUsage does not downgrade InternalError", InternalError, BadUsage, InternalError},
+		{"InternalError beats TestFail", TestFail, InternalError, InternalError},
+		{"InternalError beats TestPass", TestPass, InternalError, InternalError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeExitCode(tt.prev, tt.next); got != tt.want {
+				t.Errorf("mergeExitCode(%d, %d) = %d, want %d", tt.prev, tt.next, got, tt.want)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -621,6 +621,47 @@ func TestSetupLoggingPluginCreatesFiles(t *testing.T) {
 	}
 }
 
+func BenchmarkNewConfig(b *testing.B) {
+	cfg := `
+services:
+  bench-service:
+    policy:
+      catalogs:
+        - FINOS-CCC
+      applicability: ["tlp_green"]
+    vars:
+      key: value
+`
+	viper.Reset()
+	viper.SetConfigType("yaml")
+	if err := viper.ReadConfig(bytes.NewBufferString(cfg)); err != nil {
+		b.Fatalf("error reading config: %v", err)
+	}
+	viper.Set("service", "bench-service")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewConfig([]string{"key"})
+	}
+}
+
+func BenchmarkSanitizeVars(b *testing.B) {
+	vars := map[string]interface{}{
+		"token":        "secret-token",
+		"password":     "my-password",
+		"api_key":      "abc123",
+		"AccessToken":  "xyz",
+		"username":     "testuser",
+		"region":       "us-west-2",
+		"endpoint":     "https://example.com",
+		"clientsecret": "shh",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sanitizeVars(vars)
+	}
+}
+
 func TestSetupLoggingFilesAndDirectories(t *testing.T) {
 	tmpDir := path.Join(os.TempDir(), "privateer-test")
 	defer func() {

--- a/config/getters_test.go
+++ b/config/getters_test.go
@@ -256,3 +256,57 @@ func TestGetServicePlugin(t *testing.T) {
 		t.Errorf("GetServicePlugin(\"nonexistent\") = %q, want empty", got)
 	}
 }
+
+func BenchmarkGetVar_Hit(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = testConfig.GetVar("stringKey")
+	}
+}
+
+func BenchmarkGetVar_Miss(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = testConfig.GetVar("doesNotExist")
+	}
+}
+
+func BenchmarkGetString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetString("stringKey")
+	}
+}
+
+func BenchmarkGetInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetInt("intKey")
+	}
+}
+
+func BenchmarkGetBool(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetBool("boolKey")
+	}
+}
+
+func BenchmarkGetMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetMap("map[string]interface {}Key")
+	}
+}
+
+func BenchmarkGetStringSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetStringSlice("[]stringKey")
+	}
+}
+
+func BenchmarkGetIntSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetIntSlice("[]intKey")
+	}
+}
+
+func BenchmarkGetString_TypeMismatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = testConfig.GetString("intKey")
+	}
+}

--- a/pluginkit/errors.go
+++ b/pluginkit/errors.go
@@ -1,64 +1,80 @@
 // Package pluginkit provides the core plugin kit functionality for building Privateer plugins.
 //
-// This file contains error definitions to streamline testing and log management.
+// Each error factory wraps one of the two category sentinels below so
+// ExitCodeFor can classify it into the right exit code via errors.Is.
 package pluginkit
 
 import (
+	"errors"
 	"fmt"
 )
+
+// ErrRuntime classifies failures during plugin execution that aren't the
+// plugin author's fault (loader, write, RPC, corruption). Maps to InternalError.
+var ErrRuntime = errors.New("privateer plugin runtime error")
+
+// ErrDevBug classifies SDK misuse or malformed plugin data (missing catalogs,
+// unset names, missing assessment steps). Maps to BadUsage.
+var ErrDevBug = errors.New("privateer plugin development error")
 
 // Error functions that require no parameters.
 var (
 	CORRUPTION_FOUND = func(mod string) error {
-		return errMod("target state may be corrupted! Halting to prevent futher damage. See logs for more information", mod)
+		return wrap(ErrRuntime, "target state may be corrupted! Halting to prevent futher damage. See logs for more information", mod)
 	}
 	NO_EVALUATION_SUITES = func(mod string) error {
-		return errMod("no control evaluations provided by the plugin", mod)
+		return wrap(ErrDevBug, "no control evaluations provided by the plugin", mod)
 	}
 	EVAL_NAME_MISSING = func(mod string) error {
-		return errMod("evaluationSuite name must not be empty", mod)
+		return wrap(ErrDevBug, "evaluationSuite name must not be empty", mod)
 	}
 	CONFIG_NOT_INITIALIZED = func(mod string) error {
-		return errMod("configuration not initialized", mod)
+		return wrap(ErrDevBug, "configuration not initialized", mod)
 	}
 	NO_ASSESSMENT_STEPS_PROVIDED = func(mod string) error {
-		return errMod("assessment steps not provided", mod)
+		return wrap(ErrDevBug, "assessment steps not provided", mod)
 	}
 	NO_ASSESSMENT_REQS_PROVIDED = func(mod string) error {
-		return errMod("assessment requirements not provided", mod)
+		return wrap(ErrDevBug, "assessment requirements not provided", mod)
 	}
 	EVAL_SUITE_CRASHED = func(mod string) error {
-		return errMod("evaluation suite crashed", mod)
+		return wrap(ErrDevBug, "evaluation suite crashed", mod)
 	}
 )
 
 // Error functions that require parameters.
 var (
 	EVALUATION_ORCHESTRATOR_NAMES_NOT_SET = func(serviceName, pluginName string, mod string) error {
-		return errMod(fmt.Errorf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", serviceName, pluginName), mod)
+		return wrap(ErrDevBug, fmt.Sprintf("expected service and plugin names to be set. ServiceName='%s' PluginName='%s'", serviceName, pluginName), mod)
 	}
 	WRITE_FAILED = func(name, err string, mod string) error {
-		return errMod(fmt.Errorf("failed to write results for evaluation suite. name: %s, error: %s", name, err), mod)
+		return wrap(ErrRuntime, fmt.Sprintf("failed to write results for evaluation suite. name: %s, error: %s", name, err), mod)
 	}
 	BAD_LOADER = func(pluginName string, err error, mod string) error {
-		return errMod(fmt.Errorf("failed to load payload for %s: %s", pluginName, err), mod)
+		return wrap(ErrRuntime, fmt.Sprintf("failed to load payload for %s: %s", pluginName, err), mod)
 	}
 	BAD_CATALOG = func(pluginName string, errMsg string, mod string) error {
-		return errMod(fmt.Errorf("malformed data in catalog for %s: %s", pluginName, errMsg), mod)
+		return wrap(ErrDevBug, fmt.Sprintf("malformed data in catalog for %s: %s", pluginName, errMsg), mod)
 	}
 	BAD_EVAL_LOG = func(err error, mod string) error {
-		return errMod(fmt.Errorf("failed to setup evaluation log: %w", err), mod)
+		return wrap(ErrDevBug, fmt.Sprintf("failed to setup evaluation log: %s", err), mod)
 	}
 	BAD_ASSESSMENT_REQS = func(err error, mod string) error {
-		return errMod(fmt.Errorf("failed to load assessment requirements from catalog: %w", err), mod)
+		return wrap(ErrDevBug, fmt.Sprintf("failed to load assessment requirements from catalog: %s", err), mod)
 	}
 	BAD_CONFIG = func(err error, mod string) error {
-		return errMod(fmt.Errorf("failed to setup config: %w", err), mod)
+		return wrap(ErrRuntime, fmt.Sprintf("failed to setup config: %s", err), mod)
 	}
 	NO_MATCHING_CATALOGS = func(requested []string, available []string, mod string) error {
-		return errMod(fmt.Errorf("no requested catalogs matched available suites. requested=%v available=%v", requested, available), mod)
+		return wrap(ErrDevBug, fmt.Sprintf("no requested catalogs matched available suites. requested=%v available=%v", requested, available), mod)
 	}
 )
+
+// wrap chains the category sentinel via %w so errors.Is works, while keeping
+// the legacy "msg+mod" prefix that existing tests substring-match against.
+func wrap(sentinel error, msg, mod string) error {
+	return fmt.Errorf("%s+%s: %w", msg, mod, sentinel)
+}
 
 func errMod(err any, mod string) error {
 	if err != nil {

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -136,10 +136,10 @@ func (v *EvaluationOrchestrator) addEvaluationSuite(catalog *gemara.ControlCatal
 		config:    v.config,
 	}
 
+	// Leave suite.loader nil when no override is given so loadPayload
+	// reuses the orchestrator payload instead of re-running v.loader per suite.
 	if loader != nil {
 		suite.loader = loader
-	} else {
-		suite.loader = v.loader
 	}
 	v.possibleSuites = append(v.possibleSuites, &suite)
 }
@@ -323,15 +323,13 @@ func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result [
 
 // loadPayload loads the payload data to be referenced in assessments.
 func (v *EvaluationOrchestrator) loadPayload() (err error) {
-	payload := new(interface{})
 	if v.loader != nil {
 		data, err := v.loader(v.config)
 		if err != nil {
 			return err
 		}
-		payload = &data
+		v.Payload = data
 	}
-	v.Payload = payload
 	for _, suite := range v.possibleSuites {
 		if suite.loader != nil {
 			data, err := suite.loader(v.config)

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -489,6 +489,59 @@ func createTestEvalLog() gemara.EvaluationLog {
 	}
 }
 
+func BenchmarkGetImportedControls(b *testing.B) {
+	primary := &gemara.ControlCatalog{
+		Metadata: gemara.Metadata{Id: "primary"},
+		Controls: []gemara.Control{
+			{Id: "P-1"},
+		},
+		Imports: []gemara.MultiEntryMapping{
+			{
+				ReferenceId: "imported",
+				Entries: []gemara.ArtifactMapping{
+					{ReferenceId: "I-1"},
+					{ReferenceId: "I-2"},
+				},
+			},
+		},
+	}
+	imported := &gemara.ControlCatalog{
+		Metadata: gemara.Metadata{Id: "imported"},
+		Controls: []gemara.Control{
+			{Id: "I-1"},
+			{Id: "I-2"},
+			{Id: "I-3"},
+		},
+	}
+	refs := map[string]*gemara.ControlCatalog{
+		"primary":  primary,
+		"imported": imported,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = getImportedControls(primary, refs)
+	}
+}
+
+func BenchmarkAddPossibleControls(b *testing.B) {
+	catalog := getTestCatalogWithRequirements()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		orchestrator := &EvaluationOrchestrator{}
+		orchestrator.addPossibleControls(catalog)
+	}
+}
+
+func BenchmarkGetPluginCatalogs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := getPluginCatalogs("catalog-test-data", testDataFS)
+		if err != nil {
+			b.Fatalf("getPluginCatalogs failed: %v", err)
+		}
+	}
+}
+
 func TestEvaluationOrchestrator_WriteResults_SARIF(t *testing.T) {
 	t.Run("SARIF output with PluginUri", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "test-sarif-")

--- a/pluginkit/evaluation_suite_test.go
+++ b/pluginkit/evaluation_suite_test.go
@@ -7,6 +7,56 @@ import (
 	"github.com/gemaraproj/go-gemara"
 )
 
+func BenchmarkEvaluate_Passing(b *testing.B) {
+	cfg := setBasicConfig()
+	steps := createPassingStepsMap()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		suite := &EvaluationSuite{
+			Name:    "bench",
+			catalog: getTestCatalogWithRequirements(),
+			steps:   steps,
+			config:  cfg,
+		}
+		b.StartTimer()
+		if err := suite.Evaluate("bench-service"); err != nil {
+			b.Fatalf("Evaluate failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkSetupEvalLog(b *testing.B) {
+	suite := &EvaluationSuite{
+		catalog:   getTestCatalogWithRequirements(),
+		CatalogId: "CCC.ObjStor",
+		config:    setBasicConfig(),
+	}
+	steps := createPassingStepsMap()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := suite.setupEvalLog(steps)
+		if err != nil {
+			b.Fatalf("setupEvalLog failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetAssessmentRequirements(b *testing.B) {
+	suite := &EvaluationSuite{
+		catalog: getTestCatalogWithRequirements(),
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := suite.GetAssessmentRequirements()
+		if err != nil {
+			b.Fatalf("GetAssessmentRequirements failed: %v", err)
+		}
+	}
+}
+
 func TestEvaluate(t *testing.T) {
 	testData := getTestEvaluateData()
 
@@ -31,9 +81,8 @@ func TestEvaluate(t *testing.T) {
 			} else if err != nil && test.expectedEvalSuiteError == nil {
 				// For now, we expect an error about missing assessment requirements when catalog is empty
 				// This is expected behavior with the current implementation
-				expectedMessage := NO_ASSESSMENT_STEPS_PROVIDED("")
-				if !strings.Contains(err.Error(), expectedMessage.Error()) {
-					t.Errorf("Expected error containing '%s', but got '%v'", expectedMessage, err)
+				if !strings.Contains(err.Error(), "assessment steps not provided") {
+					t.Errorf("Expected error mentioning 'assessment steps not provided', but got '%v'", err)
 				}
 			} else if err == nil && test.expectedEvalSuiteError != nil {
 				t.Errorf("Expected error '%s', but got no error", test.expectedEvalSuiteError)

--- a/pluginkit/exitcode.go
+++ b/pluginkit/exitcode.go
@@ -1,0 +1,38 @@
+package pluginkit
+
+import (
+	"errors"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/privateerproj/privateer-sdk/shared"
+)
+
+// ExitCodeFor maps the outcome of EvaluationOrchestrator.Mobilize into a
+// canonical privateer exit code. Plugin authors call this from Start:
+//
+//	func (p *Plugin) Start() (int, error) {
+//	    err := p.orchestrator.Mobilize()
+//	    return pluginkit.ExitCodeFor(p.orchestrator, err), err
+//	}
+//
+// A non-nil error wrapping ErrRuntime → InternalError; ErrDevBug → BadUsage;
+// any other non-nil error → InternalError. With nil error, suite results
+// containing Failed/NeedsReview/Unknown → TestFail; otherwise TestPass.
+func ExitCodeFor(orch *EvaluationOrchestrator, mobilizeErr error) int {
+	if mobilizeErr != nil {
+		if errors.Is(mobilizeErr, ErrDevBug) {
+			return shared.BadUsage
+		}
+		return shared.InternalError
+	}
+	if orch == nil {
+		return shared.TestPass
+	}
+	for _, suite := range orch.Evaluation_Suites {
+		switch suite.Result {
+		case gemara.Failed, gemara.NeedsReview, gemara.Unknown:
+			return shared.TestFail
+		}
+	}
+	return shared.TestPass
+}

--- a/pluginkit/exitcode_test.go
+++ b/pluginkit/exitcode_test.go
@@ -1,0 +1,196 @@
+package pluginkit
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/privateerproj/privateer-sdk/shared"
+)
+
+func TestExitCodeFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		orchestrator *EvaluationOrchestrator
+		err          error
+		want         int
+	}{
+		{
+			name:         "nil error, nil orchestrator returns TestPass",
+			orchestrator: nil,
+			err:          nil,
+			want:         shared.TestPass,
+		},
+		{
+			name:         "nil error, no suites returns TestPass",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          nil,
+			want:         shared.TestPass,
+		},
+		{
+			name: "nil error, all suites passed returns TestPass",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.Passed},
+					{Result: gemara.Passed},
+				},
+			},
+			err:  nil,
+			want: shared.TestPass,
+		},
+		{
+			name: "nil error, NotRun and NotApplicable count as pass",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.NotRun},
+					{Result: gemara.NotApplicable},
+					{Result: gemara.Passed},
+				},
+			},
+			err:  nil,
+			want: shared.TestPass,
+		},
+		{
+			name: "nil error, one suite Failed returns TestFail",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.Passed},
+					{Result: gemara.Failed},
+				},
+			},
+			err:  nil,
+			want: shared.TestFail,
+		},
+		{
+			name: "nil error, NeedsReview returns TestFail",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.NeedsReview},
+				},
+			},
+			err:  nil,
+			want: shared.TestFail,
+		},
+		{
+			name: "nil error, Unknown returns TestFail",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.Unknown},
+				},
+			},
+			err:  nil,
+			want: shared.TestFail,
+		},
+		{
+			name:         "BAD_LOADER returns InternalError",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          BAD_LOADER("svc", errors.New("connection refused"), "mob30"),
+			want:         shared.InternalError,
+		},
+		{
+			name:         "BAD_CONFIG returns InternalError",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          BAD_CONFIG(errors.New("missing field"), "mob10"),
+			want:         shared.InternalError,
+		},
+		{
+			name:         "WRITE_FAILED returns InternalError",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          WRITE_FAILED("svc", "disk full", "wr40"),
+			want:         shared.InternalError,
+		},
+		{
+			name:         "CORRUPTION_FOUND returns InternalError",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          CORRUPTION_FOUND("ev40"),
+			want:         shared.InternalError,
+		},
+		{
+			name:         "NO_EVALUATION_SUITES returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          NO_EVALUATION_SUITES("mob50"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "BAD_CATALOG returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          BAD_CATALOG("svc", "no controls", "aos20"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "CONFIG_NOT_INITIALIZED returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          CONFIG_NOT_INITIALIZED("ev10"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "NO_ASSESSMENT_STEPS_PROVIDED returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          NO_ASSESSMENT_STEPS_PROVIDED("sel10"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "EVAL_SUITE_CRASHED returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          EVAL_SUITE_CRASHED("sel20"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "EVALUATION_ORCHESTRATOR_NAMES_NOT_SET returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          EVALUATION_ORCHESTRATOR_NAMES_NOT_SET("svc", "plg", "mob40"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "NO_MATCHING_CATALOGS returns BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          NO_MATCHING_CATALOGS([]string{"a"}, []string{"b"}, "mob60"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "BAD_EVAL_LOG wrapping NO_ASSESSMENT_STEPS still classifies as BadUsage",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          BAD_EVAL_LOG(NO_ASSESSMENT_STEPS_PROVIDED("sel10"), "ev30"),
+			want:         shared.BadUsage,
+		},
+		{
+			name:         "unclassified error returns InternalError as safe default",
+			orchestrator: &EvaluationOrchestrator{},
+			err:          errors.New("something exploded"),
+			want:         shared.InternalError,
+		},
+		{
+			name: "error wins over suite results",
+			orchestrator: &EvaluationOrchestrator{
+				Evaluation_Suites: []*EvaluationSuite{
+					{Result: gemara.Failed},
+				},
+			},
+			err:  BAD_LOADER("svc", errors.New("nope"), "mob30"),
+			want: shared.InternalError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExitCodeFor(tt.orchestrator, tt.err)
+			if got != tt.want {
+				t.Errorf("ExitCodeFor = %d, want %d (err=%v)", got, tt.want, tt.err)
+			}
+		})
+	}
+}
+
+// Plugin authors will wrap pluginkit errors with their own context; the
+// category sentinel must survive an extra fmt.Errorf("%w") layer.
+func TestErrorSentinelsSurviveWrapping(t *testing.T) {
+	runtime := fmt.Errorf("ctx: %w", BAD_LOADER("svc", errors.New("x"), "m"))
+	if !errors.Is(runtime, ErrRuntime) {
+		t.Errorf("wrapped BAD_LOADER did not satisfy errors.Is(ErrRuntime)")
+	}
+	devBug := fmt.Errorf("ctx: %w", NO_EVALUATION_SUITES("m"))
+	if !errors.Is(devBug, ErrDevBug) {
+		t.Errorf("wrapped NO_EVALUATION_SUITES did not satisfy errors.Is(ErrDevBug)")
+	}
+}

--- a/shared/exitcodes.go
+++ b/shared/exitcodes.go
@@ -1,0 +1,12 @@
+package shared
+
+// Canonical exit codes. Defined here so command/ and pluginkit/ can both
+// reference them without an import cycle.
+const (
+	TestPass = iota
+	TestFail
+	Aborted
+	InternalError
+	BadUsage
+	NoTests
+)

--- a/shared/plugin.go
+++ b/shared/plugin.go
@@ -2,23 +2,38 @@
 package shared
 
 import (
+	"errors"
 	"net/rpc"
 
 	hcplugin "github.com/hashicorp/go-plugin"
 )
 
-// Pluginer is the interface that we're exposing as a plugin.
+// Pluginer is the interface that we're exposing as a plugin. Start returns a
+// privateer exit code (TestPass, TestFail, InternalError, BadUsage) and an
+// optional error for diagnostic logging. Typed errors do not survive net/rpc,
+// so classification must happen on the plugin side — see pluginkit.ExitCodeFor.
 type Pluginer interface {
-	Start() error
+	Start() (int, error)
+}
+
+type startResponse struct {
+	ExitCode int
+	Err      string
 }
 
 // PluginRPC is an implementation that talks over RPC.
 type PluginRPC struct{ client *rpc.Client }
 
 // Start is a wrapper for interface implementation of Start.
-func (g *PluginRPC) Start() error {
-	var err error
-	return g.client.Call("Plugin.Start", new(interface{}), &err)
+func (g *PluginRPC) Start() (int, error) {
+	var resp startResponse
+	if err := g.client.Call("Plugin.Start", new(interface{}), &resp); err != nil {
+		return InternalError, err
+	}
+	if resp.Err != "" {
+		return resp.ExitCode, errors.New(resp.Err)
+	}
+	return resp.ExitCode, nil
 }
 
 // PluginRPCServer is the RPC server that PluginRPC talks to, conforming to
@@ -29,9 +44,13 @@ type PluginRPCServer struct {
 }
 
 // Start is a wrapper for interface implementation.
-func (s *PluginRPCServer) Start(args interface{}, resp *error) error {
-	*resp = s.Impl.Start()
-	return *resp
+func (s *PluginRPCServer) Start(args interface{}, resp *startResponse) error {
+	code, err := s.Impl.Start()
+	resp.ExitCode = code
+	if err != nil {
+		resp.Err = err.Error()
+	}
+	return nil
 }
 
 // Plugin is the implementation of plugin.Plugin so we can serve/consume this.

--- a/shared/plugin.go
+++ b/shared/plugin.go
@@ -16,7 +16,7 @@ type Pluginer interface {
 	Start() (int, error)
 }
 
-type startResponse struct {
+type StartResponse struct {
 	ExitCode int
 	Err      string
 }
@@ -26,7 +26,7 @@ type PluginRPC struct{ client *rpc.Client }
 
 // Start is a wrapper for interface implementation of Start.
 func (g *PluginRPC) Start() (int, error) {
-	var resp startResponse
+	var resp StartResponse
 	if err := g.client.Call("Plugin.Start", new(interface{}), &resp); err != nil {
 		return InternalError, err
 	}
@@ -44,7 +44,7 @@ type PluginRPCServer struct {
 }
 
 // Start is a wrapper for interface implementation.
-func (s *PluginRPCServer) Start(args interface{}, resp *startResponse) error {
+func (s *PluginRPCServer) Start(args interface{}, resp *StartResponse) error {
 	code, err := s.Impl.Start()
 	resp.ExitCode = code
 	if err != nil {


### PR DESCRIPTION
This enables plugins to pass an exit code to the runner, instead of only the error. This allows for more granular exits than complete / error.

> [!WARNING]
> This is a breaking change.
> 
> The change set should be nominal, but auto-upgrades will not be possible.