### PR TITLE
ci: adopt consolidated ospo-reusable-workflows release.yaml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write       # Create release and push tags
       pull-requests: read   # Read PR labels for release-drafter
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml


### PR DESCRIPTION
## What

Bump the `release.yaml` reusable workflow pin to v1.0.0 (`592067a6...`), which collapses the previous three-workflow release/release-image/release-discussion pipeline into a single draft-first workflow. Also add a "Breaking Changes" category to release-drafter so PRs labeled `breaking` get their own section in the generated changelog.

## Why

The pinned SHA was the pre-consolidation version. Moving to v1.0.0 puts this repo on the supported release flow and aligns it with the pvtr CLI's release workflow. Because pvtr-sdk ships no binaries or container images, only the `create_release` / `publish_release` portion of the consolidated workflow runs; the existing `contents: write` + `pull-requests: read` permissions are still all that's needed. The "Breaking Changes" category matches the upstream release-drafter template (github-community-projects/ospo-reusable-workflows#134); the `breaking` label was already wired up under `version-resolver.major`, so this just surfaces those PRs in their own changelog section.

## Notes

- No `goreleaser-config-path` or `image-name` inputs are passed, so the optional `release_goreleaser` and `release_image` jobs in the reusable workflow are skipped at the job-level `if:` and never spin up runners.
- Likewise, no `id-token: write` / `attestations: write` permissions are needed here since there are no artifacts to attest.
- `create-discussion` is intentionally not enabled; flip on later with the input plus `discussion-repository-id` / `discussion-category-id` secrets if we want auto-announcements.

## Testing

- `make test` — passes (`command`, `config`, `internal/...`, `pluginkit`, `utils` all green).
- `golangci-lint run ./...` — 0 issues.
- End-to-end release flow is not exercised locally; first real validation will be the next merged PR carrying a `feature`/`fix`/`breaking`/`vuln`/`release` label that fires `pull_request_target: closed`. Watch for: release-drafter creating a draft, `create_release` pushing the new tag plus the major-version moving tag, optional jobs (`release_goreleaser`, `release_image`, `release_discussion`) showing as skipped, and `publish_release` flipping the draft to published.