### PR TITLE
fix: grant full union of permissions for nested release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   release:
     permissions:
-      contents: write       # Create release and push tags
-      pull-requests: read   # Read PR labels for release-drafter
+      contents: write       # create_release, publish_release: tag + release
+      pull-requests: read   # create_release: read PR labels for release-drafter
+      id-token: write       # release_goreleaser, release_image: attestation OIDC
+      attestations: write   # release_goreleaser, release_image: build provenance
+      packages: write       # release_image: push container image (gated, but validated)
+      discussions: write    # release_discussion: announcement (gated, defensive)
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true


### PR DESCRIPTION
## What

Expand the `release` job's `permissions:` block to grant `id-token: write`, `attestations: write`, `packages: write`, and `discussions: write` in addition to the existing two. The block now covers the union of permissions declared by every job in the called `ospo-reusable-workflows/release.yaml@v1.0.1`.

## Why

The merge of #211 left main on the consolidated workflow with only `contents: write` + `pull-requests: read`. The `pull_request_target: closed` Release run that fired on merge failed with `startup_failure`:

> The nested job 'release_image' is requesting 'attestations: write, packages: write, id-token: write', but is only allowed 'attestations: none, packages: none, id-token: none'.

GitHub validates each nested job's `permissions:` against the caller's grant at workflow startup, **before** evaluating that job's `if:` — except when the gate folds statically to `false`. The gates on `release_goreleaser` (`inputs.goreleaser-config-path != ''`) and `release_image` (`inputs.image-name != ''`) are string comparisons the validator can't fold, so their perms are checked even though both jobs would have been skipped at runtime here (this repo sets neither input).

## Notes

- `release_discussion`'s gate (`inputs.create-discussion && ...`) DOES fold statically (boolean default `false`), so the validator skips it today and `discussions: write` is not technically required. Granted anyway as a defensive measure in case the upstream rearranges that `if:` later — it costs nothing today and prevents a future silent regression.
- This PR carries the `release` label so the now-fixed workflow fires on merge and cuts the release that #211 never produced.
- Reviewers: please watch the Release run on the merge commit — `create_release` + `publish_release` should succeed, and `release_goreleaser` / `release_image` / `release_discussion` should appear as skipped.

## Testing

- `make test` — passes (command, config, internal/install, internal/manifest, internal/registry, pluginkit, utils all green).
- `golangci-lint run ./...` — 0 issues.
- The fix itself is the workflow file change. Real validation is the post-merge Release run cutting a release; no local dry-run is possible for `pull_request_target` chain.