### PR TITLE
feat: add provider-neutral AIClient foundation with OpenAI adapter

### DIFF
--- a/ai/client.go
+++ b/ai/client.go
@@ -1,0 +1,220 @@
+// Package ai defines the provider-neutral contract callers use to talk to
+// any AI backend. Concrete providers (e.g. OpenAI) are implemented as
+// adapters that satisfy the Client interface and are registered in
+// clientFactories. Callers should depend only on the types in this file so
+// that swapping or adding providers does not require changes outside the
+// ai package.
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Provider identifies the AI backend implementation. Each supported provider
+// gets its own constant and a matching entry in clientFactories.
+type Provider string
+
+const (
+	ProviderOpenAI Provider = "openai"
+	// Additional providers (e.g. Anthropic, Gemini) should be added here
+	// alongside a corresponding entry in clientFactories.
+)
+
+const (
+	defaultTimeout   = 30 * time.Second
+	defaultMaxTokens = 256
+)
+
+// clientFactory builds a provider adapter from a normalized Config. Each
+// adapter lives in its own file (e.g. openai.go) and is wired in below.
+type clientFactory func(Config) Client
+
+// clientFactories is the provider registry. Adding a new provider is a matter
+// of implementing a Client and registering its constructor here; no caller
+// code needs to change.
+var clientFactories = map[Provider]clientFactory{
+	ProviderOpenAI: func(config Config) Client {
+		return newOpenAIClient(config)
+	},
+}
+
+// Client is the provider-neutral analysis contract. Every adapter must
+// satisfy it so callers can swap providers without touching call sites.
+type Client interface {
+	Analyze(ctx context.Context, prompt, content string, schema *Schema) (*AnalyzeResponse, error)
+}
+
+// Config holds the provider-neutral settings used to construct any adapter.
+// Provider-specific concerns (auth header shape, endpoint paths, request body
+// schema) are the adapter's responsibility, not this struct's.
+type Config struct {
+	// Provider selects which adapter is constructed via clientFactories.
+	Provider Provider
+	// APIKey is the credential passed to the provider. Adapters decide how
+	// it is attached to outbound requests (e.g. Bearer header, x-api-key).
+	APIKey string
+	// Model is the provider-specific model identifier (e.g. "gpt-4o-mini").
+	// Lets callers pick the cost/quality tradeoff appropriate for the task.
+	Model string
+	// BaseURL overrides the adapter's default endpoint. Primarily useful for
+	// tests, proxies, and self-hosted gateways. Empty means use the default.
+	BaseURL string
+	// Timeout bounds a single Analyze call so a slow or hung provider cannot
+	// stall the caller indefinitely. Zero falls back to defaultTimeout.
+	Timeout time.Duration
+	// MaxTokens caps the response length, bounding cost and latency per call.
+	// Zero falls back to defaultMaxTokens.
+	MaxTokens int
+	// HTTPClient lets callers inject a custom transport (e.g. for tests or
+	// instrumentation). When nil, a client honoring Timeout is constructed.
+	HTTPClient *http.Client
+}
+
+// Schema tells the provider to return a structured JSON answer instead of
+// free-form text. Callers describe the exact shape they want with a JSON
+// Schema document, and the adapter translates that into whatever the
+// underlying provider expects (OpenAI's response_format json_schema,
+// Anthropic tool input schemas, Gemini's responseSchema, etc.). When a
+// Schema is supplied, AnalyzeResponse.JSON holds the parsed payload, ready
+// to json.Unmarshal into a Go type.
+//
+// Example: ask the model to grade a repository's documentation and return
+// a verdict the caller can act on programmatically.
+//
+//	schema := &ai.Schema{
+//	    Name:        "doc_grade",
+//	    Description: "Grade for a repository's documentation quality.",
+//	    Strict:      true,
+//	    Value: json.RawMessage(`{
+//	        "type": "object",
+//	        "properties": {
+//	            "verdict":    {"type": "string", "enum": ["pass", "fail"]},
+//	            "confidence": {"type": "number"},
+//	            "reason":     {"type": "string"}
+//	        },
+//	        "required": ["verdict", "confidence", "reason"],
+//	        "additionalProperties": false
+//	    }`),
+//	}
+//
+//	resp, err := client.Analyze(ctx, prompt, readme, schema)
+//	// resp.JSON: {"verdict":"pass","confidence":0.82,"reason":"..."}
+type Schema struct {
+	// Name labels the schema for the provider (some providers display or
+	// log it). Think of it as the form's title. Required when Schema is
+	// supplied.
+	Name string
+	// Description is a short sentence telling the model what the schema is
+	// for. Optional, but improves output quality when field names alone
+	// are ambiguous. Passed through to providers that support it.
+	Description string
+	// Value is the JSON Schema document the response must conform to —
+	// the "form definition." Callers typically json.Unmarshal
+	// AnalyzeResponse.JSON into a Go type derived from this schema.
+	Value json.RawMessage
+	// Strict asks the provider to reject responses that do not match Value
+	// exactly ("strict form-filling") instead of doing its best.
+	// Providers that do not support strict mode ignore this flag.
+	Strict bool
+}
+
+// AnalyzeResponse is the normalized result returned by every adapter.
+// When Analyze is called without a Schema, only Text is populated. When a
+// Schema is supplied, JSON holds the parsed structured payload and Text
+// holds the raw message content the provider returned.
+type AnalyzeResponse struct {
+	// Text is the raw text content of the model's response. Use this for
+	// free-form prompts where no structured output was requested.
+	Text string
+	// JSON is the parsed structured payload. Non-nil only when the caller
+	// supplied a Schema and the provider produced valid JSON. Callers can
+	// json.Unmarshal it into a typed Go value matching the schema.
+	JSON json.RawMessage
+	// Metadata describes the response in provider-neutral terms.
+	Metadata ResponseMetadata
+}
+
+// ResponseMetadata is diagnostic metadata about an Analyze call. The SDK
+// does not read these fields itself — they are returned so callers can log
+// them, persist them in audit trails, attribute results when juggling
+// multiple clients, or branch on signals like FinishReason. Adapters
+// translate each provider's native response details into this uniform
+// shape so callers do not need provider-specific knowledge.
+type ResponseMetadata struct {
+	// Provider is the adapter that produced the response. Useful when a
+	// caller mixes clients from multiple providers and wants to attribute
+	// each result.
+	Provider Provider
+	// Model is the model name the provider reports having used. It may
+	// differ from Config.Model when the requested name is an alias that
+	// the provider resolves to a specific pinned version (e.g.
+	// "gpt-4o-mini" -> "gpt-4o-mini-2024-07-18").
+	Model string
+	// RequestID is the provider's per-call identifier, used by callers to
+	// correlate this response with provider-side logs (support tickets,
+	// audit trails, cross-system debugging). Adapters prefer the HTTP
+	// response header when available and fall back to a body field.
+	RequestID string
+	// FinishReason is the provider's reason for ending generation
+	// (e.g. "stop", "length"). Lets callers detect truncation versus a
+	// natural stop and react accordingly (retry with more tokens, warn,
+	// etc.). Adapters pass it through verbatim.
+	FinishReason string
+}
+
+// NewClient creates a provider-specific AI client from provider-neutral
+// configuration. It validates the config, then dispatches to the adapter
+// registered for config.Provider.
+func NewClient(config Config) (Client, error) {
+	config = config.normalized()
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+
+	factory, ok := clientFactories[config.Provider]
+	if !ok {
+		return nil, fmt.Errorf("unsupported ai provider %q", config.Provider)
+	}
+
+	return factory(config), nil
+}
+
+func (c Config) validate() error {
+	if strings.TrimSpace(string(c.Provider)) == "" {
+		return fmt.Errorf("ai provider is required")
+	}
+	if strings.TrimSpace(c.APIKey) == "" {
+		return fmt.Errorf("ai api key is required")
+	}
+	if strings.TrimSpace(c.Model) == "" {
+		return fmt.Errorf("ai model is required")
+	}
+	return nil
+}
+
+func (c Config) normalized() Config {
+	c.Provider = Provider(strings.ToLower(strings.TrimSpace(string(c.Provider))))
+	c.APIKey = strings.TrimSpace(c.APIKey)
+	c.Model = strings.TrimSpace(c.Model)
+	c.BaseURL = strings.TrimSpace(c.BaseURL)
+	if c.Timeout <= 0 {
+		c.Timeout = defaultTimeout
+	}
+	if c.MaxTokens <= 0 {
+		c.MaxTokens = defaultMaxTokens
+	}
+	return c
+}
+
+func (c Config) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+
+	return &http.Client{Timeout: c.normalized().Timeout}
+}

--- a/ai/client.go
+++ b/ai/client.go
@@ -1,9 +1,9 @@
 // Package ai defines the provider-neutral contract callers use to talk to
 // any AI backend. Concrete providers (e.g. OpenAI) are implemented as
 // adapters that satisfy the Client interface and are registered in
-// clientFactories. Callers should depend only on the types in this file so
-// that swapping or adding providers does not require changes outside the
-// ai package.
+// clientFactories. Callers should use only the shared types in this package,
+// so adding or changing the SDK's built-in providers does not require changes
+// in the code that calls the SDK.
 package ai
 
 import (
@@ -34,9 +34,9 @@ const (
 // adapter lives in its own file (e.g. openai.go) and is wired in below.
 type clientFactory func(Config) Client
 
-// clientFactories is the provider registry. Adding a new provider is a matter
-// of implementing a Client and registering its constructor here; no caller
-// code needs to change.
+// clientFactories is the internal registry for the providers that ship with
+// this SDK. To add another built-in provider, implement Client and register
+// its constructor here. Code that uses the SDK does not need to change.
 var clientFactories = map[Provider]clientFactory{
 	ProviderOpenAI: func(config Config) Client {
 		return newOpenAIClient(config)
@@ -160,10 +160,10 @@ type ResponseMetadata struct {
 	// audit trails, cross-system debugging). Adapters prefer the HTTP
 	// response header when available and fall back to a body field.
 	RequestID string
-	// FinishReason is the provider's reason for ending generation
-	// (e.g. "stop", "length"). Lets callers detect truncation versus a
-	// natural stop and react accordingly (retry with more tokens, warn,
-	// etc.). Adapters pass it through verbatim.
+	// FinishReason is the provider's reason for ending generation.
+	// Adapters pass the provider's native value through unchanged, so callers
+	// should treat it as provider-specific rather than relying on one shared
+	// set of finish-reason strings across all providers.
 	FinishReason string
 }
 

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -1,0 +1,116 @@
+package ai
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// ErrorKind categorizes provider failures for consistent caller handling.
+// Adapters map their native errors into one of these kinds so callers
+// never depend on the exact wording or status code a provider returned.
+type ErrorKind string
+
+const (
+	// ErrorKindUnauthorized indicates the credential was missing, invalid,
+	// or lacks permission for the requested model.
+	ErrorKindUnauthorized ErrorKind = "unauthorized"
+	// ErrorKindRateLimited indicates the provider asked us to back off.
+	// Callers may retry with backoff.
+	ErrorKindRateLimited ErrorKind = "rate_limited"
+	// ErrorKindTimeout indicates the request did not complete within the
+	// configured Timeout or was cancelled via context.
+	ErrorKindTimeout ErrorKind = "timeout"
+	// ErrorKindProviderError is the catch-all for upstream failures that
+	// do not fall into a more specific kind (5xx, unknown 4xx, etc.).
+	ErrorKindProviderError ErrorKind = "provider_error"
+	// ErrorKindInvalidRequest indicates the request body or parameters
+	// were rejected by the provider (e.g. 400, 422).
+	ErrorKindInvalidRequest ErrorKind = "invalid_request"
+	// ErrorKindInvalidResponse indicates the provider returned data we
+	// could not parse (malformed JSON, missing choices, etc.).
+	ErrorKindInvalidResponse ErrorKind = "invalid_response"
+	// ErrorKindUnsupportedConfig indicates a caller-side configuration
+	// problem (e.g. schema supplied without a Name).
+	ErrorKindUnsupportedConfig ErrorKind = "unsupported_config"
+)
+
+// Error normalizes provider-specific failures into a uniform type.
+// Callers typically inspect Kind and, when relevant, StatusCode. The
+// original error is preserved via Err so errors.Is / errors.As still work
+// against the underlying transport-layer error.
+type Error struct {
+	Kind       ErrorKind
+	Provider   Provider
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("%s error from %s", e.Kind, e.Provider)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// classifyHTTPError maps an upstream HTTP status code into an ErrorKind
+// so callers can react to common failure modes (auth, throttling, bad
+// input) without parsing provider-specific error messages.
+func classifyHTTPError(provider Provider, statusCode int, message string) error {
+	kind := ErrorKindProviderError
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		kind = ErrorKindUnauthorized
+	case http.StatusTooManyRequests:
+		kind = ErrorKindRateLimited
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		kind = ErrorKindInvalidRequest
+	}
+
+	return &Error{
+		Kind:       kind,
+		Provider:   provider,
+		StatusCode: statusCode,
+		Message:    message,
+	}
+}
+
+// classifyTransportError maps Go HTTP client errors into the same set of
+// ErrorKinds as HTTP responses. Timeouts (context deadlines and net.Error
+// timeouts) become ErrorKindTimeout; everything else falls under
+// ErrorKindProviderError. The original error is preserved via Err so
+// errors.Is/As continues to work against the underlying error.
+func classifyTransportError(provider Provider, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, contextDeadlineExceeded) {
+		return &Error{Kind: ErrorKindTimeout, Provider: provider, Err: err, Message: err.Error()}
+	}
+
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &Error{Kind: ErrorKindTimeout, Provider: provider, Err: err, Message: err.Error()}
+	}
+
+	return &Error{Kind: ErrorKindProviderError, Provider: provider, Err: err, Message: err.Error()}
+}
+
+// contextDeadlineExceeded is a local marker error used by
+// classifyTransportError to recognize context-deadline failures via
+// errors.Is without importing context here directly.
+var contextDeadlineExceeded = errors.New("context deadline exceeded")

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -98,7 +99,7 @@ func classifyTransportError(provider Provider, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, contextDeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return &Error{Kind: ErrorKindTimeout, Provider: provider, Err: err, Message: err.Error()}
 	}
 
@@ -109,8 +110,3 @@ func classifyTransportError(provider Provider, err error) error {
 
 	return &Error{Kind: ErrorKindProviderError, Provider: provider, Err: err, Message: err.Error()}
 }
-
-// contextDeadlineExceeded is a local marker error used by
-// classifyTransportError to recognize context-deadline failures via
-// errors.Is without importing context here directly.
-var contextDeadlineExceeded = errors.New("context deadline exceeded")

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -99,7 +99,7 @@ func classifyTransportError(provider Provider, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return &Error{Kind: ErrorKindTimeout, Provider: provider, Err: err, Message: err.Error()}
 	}
 

--- a/ai/errors_test.go
+++ b/ai/errors_test.go
@@ -1,0 +1,53 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestClassifyTransportError_ContextCanceled locks in the behavior that a
+// cancelled request context maps to ErrorKindTimeout, so callers branching on
+// Kind never retry a request the user explicitly cancelled. See PR #218 review
+// discussion: https://github.com/privateerproj/privateer-sdk/pull/218#discussion_r3327923013
+func TestClassifyTransportError_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := classifyTransportError(ProviderOpenAI, ctx.Err())
+	if err == nil {
+		t.Fatal("expected non-nil error from classifyTransportError")
+	}
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *ai.Error, got %T: %v", err, err)
+	}
+	if aiErr.Kind != ErrorKindTimeout {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrorKindTimeout)
+	}
+	if aiErr.Provider != ProviderOpenAI {
+		t.Errorf("Provider = %q, want %q", aiErr.Provider, ProviderOpenAI)
+	}
+	if !errors.Is(aiErr, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) = false; underlying error not preserved: %v", aiErr.Err)
+	}
+}
+
+// TestClassifyTransportError_ContextDeadlineExceeded is the deadline-side
+// counterpart to TestClassifyTransportError_ContextCanceled and pins the
+// existing DeadlineExceeded -> Timeout mapping so neither branch regresses.
+func TestClassifyTransportError_ContextDeadlineExceeded(t *testing.T) {
+	err := classifyTransportError(ProviderOpenAI, context.DeadlineExceeded)
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *ai.Error, got %T: %v", err, err)
+	}
+	if aiErr.Kind != ErrorKindTimeout {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrorKindTimeout)
+	}
+	if !errors.Is(aiErr, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false; underlying error not preserved: %v", aiErr.Err)
+	}
+}

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -1,0 +1,174 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const defaultOpenAIBaseURL = "https://api.openai.com/v1"
+
+// openAIClient is the Client implementation for OpenAI. It embeds the
+// shared providerClient for HTTP, base URL, and error handling.
+type openAIClient struct {
+	providerClient
+}
+
+// openAIChatCompletionsRequest mirrors the JSON body POSTed to
+// /v1/chat/completions. Only the fields this adapter actually populates
+// are modeled; the rest of OpenAI's API is intentionally left out.
+type openAIChatCompletionsRequest struct {
+	Model          string                `json:"model"`
+	Messages       []openAIMessage       `json:"messages"`
+	MaxTokens      int                   `json:"max_tokens,omitempty"`
+	ResponseFormat *openAIResponseFormat `json:"response_format,omitempty"`
+}
+
+// openAIMessage is one entry in the Chat Completions "messages" array.
+// The adapter sends a system message (prompt) and a user message (content).
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// openAIResponseFormat asks OpenAI to constrain the response shape. When
+// Schema is supplied on Analyze, the adapter sets Type="json_schema" and
+// fills JSONSchema with the caller's schema document.
+type openAIResponseFormat struct {
+	Type       string                `json:"type"`
+	JSONSchema *openAIJSONSchemaWrap `json:"json_schema,omitempty"`
+}
+
+// openAIJSONSchemaWrap is OpenAI's required wrapper around a raw JSON
+// Schema document. It carries a name plus optional description/strict
+// flags that providers use when validating model output.
+type openAIJSONSchemaWrap struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Strict      bool            `json:"strict,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+}
+
+// openAIChatCompletionsResponse models the slice of the Chat Completions
+// response the adapter actually reads: the request id, the model that
+// actually served the request, the first choice's content and finish
+// reason, and an optional error envelope present on failure responses.
+type openAIChatCompletionsResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		FinishReason string `json:"finish_reason"`
+		Message      struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// newOpenAIClient constructs the OpenAI adapter. Wired into the package
+// registry via clientFactories in client.go.
+func newOpenAIClient(config Config) *openAIClient {
+	return &openAIClient{
+		providerClient: newProviderClient(ProviderOpenAI, config, defaultOpenAIBaseURL),
+	}
+}
+
+// Analyze implements the Client contract against OpenAI Chat Completions.
+// At a high level it: validates the optional Schema, builds the request
+// body (translating Schema into OpenAI's response_format when present),
+// POSTs to /chat/completions with a Bearer token, returns non-200
+// responses as classified *Error values, and finally maps the first
+// choice back into a provider-neutral AnalyzeResponse (parsing the
+// content as JSON when a schema was requested).
+func (c *openAIClient) Analyze(ctx context.Context, prompt, content string, schema *Schema) (*AnalyzeResponse, error) {
+	request := analyzeRequest{
+		Prompt:  prompt,
+		Content: content,
+		Schema:  schema,
+	}
+	if err := validateStructuredSchema(ProviderOpenAI, request.Schema); err != nil {
+		return nil, err
+	}
+
+	reqBody := openAIChatCompletionsRequest{
+		Model: c.config.Model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: request.Prompt},
+			{Role: "user", Content: request.Content},
+		},
+		MaxTokens: c.config.MaxTokens,
+	}
+
+	if request.Schema != nil {
+		reqBody.ResponseFormat = &openAIResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &openAIJSONSchemaWrap{
+				Name:        strings.TrimSpace(request.Schema.Name),
+				Description: strings.TrimSpace(request.Schema.Description),
+				Strict:      request.Schema.Strict,
+				Schema:      request.Schema.Value,
+			},
+		}
+	}
+
+	httpReq, err := c.newJSONRequest(ctx, http.MethodPost, "/chat/completions", reqBody, requestOptions{
+		Headers: map[string]string{
+			"Authorization": "Bearer " + c.config.APIKey,
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, httpResp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		message := strings.TrimSpace(string(respBody))
+		var failure openAIChatCompletionsResponse
+		if err := json.Unmarshal(respBody, &failure); err == nil && failure.Error != nil && strings.TrimSpace(failure.Error.Message) != "" {
+			message = failure.Error.Message
+		}
+		if message == "" {
+			message = fmt.Sprintf("openai returned status %d", httpResp.StatusCode)
+		}
+		return nil, classifyHTTPError(ProviderOpenAI, httpResp.StatusCode, message)
+	}
+
+	var parsed openAIChatCompletionsResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, &Error{Kind: ErrorKindInvalidResponse, Provider: ProviderOpenAI, Err: err, Message: fmt.Sprintf("decode openai response: %v", err)}
+	}
+	if len(parsed.Choices) == 0 {
+		return nil, &Error{Kind: ErrorKindInvalidResponse, Provider: ProviderOpenAI, Message: "openai response did not include any choices"}
+	}
+
+	messageContent := parsed.Choices[0].Message.Content
+	response := &AnalyzeResponse{
+		Text: messageContent,
+		Metadata: ResponseMetadata{
+			Provider:     ProviderOpenAI,
+			Model:        parsed.Model,
+			RequestID:    firstNonEmpty(httpResp.Header.Get("x-request-id"), parsed.ID),
+			FinishReason: parsed.Choices[0].FinishReason,
+		},
+	}
+
+	if request.Schema == nil {
+		return response, nil
+	}
+
+	response.JSON, err = parseStructuredOutput(ProviderOpenAI, messageContent)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -93,6 +93,13 @@ func (c *openAIClient) Analyze(ctx context.Context, prompt, content string, sche
 	if err := validateStructuredSchema(ProviderOpenAI, request.Schema); err != nil {
 		return nil, err
 	}
+	if request.Schema != nil && strings.TrimSpace(request.Schema.Name) == "" {
+		return nil, &Error{
+			Kind:     ErrorKindUnsupportedConfig,
+			Provider: ProviderOpenAI,
+			Message:  "structured output schema name is required",
+		}
+	}
 
 	reqBody := openAIChatCompletionsRequest{
 		Model: c.config.Model,

--- a/ai/openai_test.go
+++ b/ai/openai_test.go
@@ -170,6 +170,36 @@ func TestOpenAIAnalyze_StructuredOutput(t *testing.T) {
 	}
 }
 
+func TestOpenAIAnalyze_RequiresSchemaName(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "gpt-4o-mini",
+		BaseURL:  "https://example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = client.Analyze(context.Background(), "prompt", "content", &Schema{
+		Value: json.RawMessage(`{"type":"object"}`),
+	})
+	if err == nil {
+		t.Fatal("expected missing schema name error")
+	}
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aiErr.Kind != ErrorKindUnsupportedConfig {
+		t.Fatalf("unexpected error kind: %s", aiErr.Kind)
+	}
+	if aiErr.Message != "structured output schema name is required" {
+		t.Fatalf("unexpected error message: %s", aiErr.Message)
+	}
+}
+
 func TestOpenAIAnalyze_HTTPErrorKinds(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/ai/openai_test.go
+++ b/ai/openai_test.go
@@ -1,0 +1,251 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClient_OpenAI(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "gpt-4o-mini",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := client.(*openAIClient); !ok {
+		t.Fatalf("expected *openAIClient, got %T", client)
+	}
+}
+
+func TestNewClient_UsesFactoryRegistry(t *testing.T) {
+	const testProvider Provider = "test-provider"
+
+	originalFactory, hadOriginal := clientFactories[testProvider]
+	defer func() {
+		if hadOriginal {
+			clientFactories[testProvider] = originalFactory
+		} else {
+			delete(clientFactories, testProvider)
+		}
+	}()
+
+	stub := &openAIClient{}
+	clientFactories[testProvider] = func(config Config) Client {
+		return stub
+	}
+
+	client, err := NewClient(Config{
+		Provider: testProvider,
+		APIKey:   "test-key",
+		Model:    "claude",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client != stub {
+		t.Fatalf("expected factory-constructed client, got %T", client)
+	}
+}
+
+func TestParseStructuredOutput_RejectsInvalidJSON(t *testing.T) {
+	_, err := parseStructuredOutput(ProviderOpenAI, "not-json")
+	if err == nil {
+		t.Fatal("expected invalid response error, got nil")
+	}
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aiErr.Kind != ErrorKindInvalidResponse {
+		t.Fatalf("expected invalid response kind, got %s", aiErr.Kind)
+	}
+}
+
+func TestNewClient_Validate(t *testing.T) {
+	_, err := NewClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini"})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+func TestNewClient_AppliesDefaultMaxTokens(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "gpt-4o-mini",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	openAI, ok := client.(*openAIClient)
+	if !ok {
+		t.Fatalf("expected *openAIClient, got %T", client)
+	}
+	if openAI.config.MaxTokens != defaultMaxTokens {
+		t.Fatalf("expected default max tokens %d, got %d", defaultMaxTokens, openAI.config.MaxTokens)
+	}
+}
+
+func TestOpenAIAnalyze_StructuredOutput(t *testing.T) {
+	schema := &Schema{
+		Name:        "assessment_result",
+		Description: "Structured verdict for a repository assessment.",
+		Strict:      true,
+		Value:       json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("unexpected authorization header: %s", got)
+		}
+
+		var request openAIChatCompletionsRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.Model != "gpt-4o-mini" {
+			t.Fatalf("unexpected model: %s", request.Model)
+		}
+		if request.ResponseFormat == nil || request.ResponseFormat.Type != "json_schema" {
+			t.Fatalf("expected json schema response format, got %#v", request.ResponseFormat)
+		}
+		if request.ResponseFormat.JSONSchema == nil || request.ResponseFormat.JSONSchema.Name != schema.Name {
+			t.Fatalf("unexpected schema wrapper: %#v", request.ResponseFormat.JSONSchema)
+		}
+
+		w.Header().Set("x-request-id", "req-123")
+		_ = json.NewEncoder(w).Encode(openAIChatCompletionsResponse{
+			ID:    "chatcmpl-123",
+			Model: "gpt-4o-mini",
+			Choices: []struct {
+				FinishReason string `json:"finish_reason"`
+				Message      struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			}{
+				{
+					FinishReason: "stop",
+					Message: struct {
+						Content string `json:"content"`
+					}{Content: `{"verdict":"PASS"}`},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "gpt-4o-mini",
+		BaseURL:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	response, err := client.Analyze(context.Background(), "analyze this repository", "README content", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(response.JSON) != `{"verdict":"PASS"}` {
+		t.Fatalf("unexpected JSON payload: %s", response.JSON)
+	}
+	if response.Metadata.Provider != ProviderOpenAI {
+		t.Fatalf("unexpected provider: %s", response.Metadata.Provider)
+	}
+	if response.Metadata.RequestID != "req-123" {
+		t.Fatalf("unexpected request id: %s", response.Metadata.RequestID)
+	}
+}
+
+func TestOpenAIAnalyze_HTTPErrorKinds(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantKind   ErrorKind
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, wantKind: ErrorKindUnauthorized},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, wantKind: ErrorKindRateLimited},
+		{name: "provider error", statusCode: http.StatusServiceUnavailable, wantKind: ErrorKindProviderError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]string{"message": "provider said no"},
+				})
+			}))
+			defer server.Close()
+
+			client, err := NewClient(Config{
+				Provider: ProviderOpenAI,
+				APIKey:   "test-key",
+				Model:    "gpt-4o-mini",
+				BaseURL:  server.URL,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, err = client.Analyze(context.Background(), "prompt", "content", nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var aiErr *Error
+			if !errors.As(err, &aiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if aiErr.Kind != tt.wantKind {
+				t.Fatalf("expected error kind %s, got %s", tt.wantKind, aiErr.Kind)
+			}
+		})
+	}
+}
+
+func TestOpenAIAnalyze_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-123","model":"gpt-4o-mini","choices":[{"finish_reason":"stop","message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "gpt-4o-mini",
+		BaseURL:  server.URL,
+		Timeout:  10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = client.Analyze(context.Background(), "prompt", "content", nil)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aiErr.Kind != ErrorKindTimeout {
+		t.Fatalf("expected timeout error kind, got %s", aiErr.Kind)
+	}
+}

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -1,0 +1,180 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// analyzeRequest is the internal, provider-neutral form of an Analyze call.
+// Adapters translate it into whatever the underlying API expects.
+type analyzeRequest struct {
+	Prompt  string
+	Content string
+	Schema  *Schema
+}
+
+// providerClient is the shared base type embedded by each adapter. It owns
+// the HTTP client, the resolved base URL, and the provider identity used
+// when constructing normalized errors.
+type providerClient struct {
+	provider   Provider
+	config     Config
+	httpClient *http.Client
+	baseURL    string
+}
+
+// requestOptions carries per-call HTTP extras (auth headers, query params)
+// that adapters layer on top of the JSON body built by newJSONRequest.
+type requestOptions struct {
+	Headers map[string]string
+	Query   url.Values
+}
+
+// newProviderClient constructs the shared base used by an adapter. It
+// resolves the effective base URL (caller override or the adapter's
+// default) and the HTTP client (caller-supplied or Timeout-honoring).
+func newProviderClient(provider Provider, config Config, defaultBaseURL string) providerClient {
+	return providerClient{
+		provider:   provider,
+		config:     config,
+		httpClient: config.httpClient(),
+		baseURL:    normalizeBaseURL(config.BaseURL, defaultBaseURL),
+	}
+}
+
+// newJSONRequest builds an *http.Request with a JSON body and the supplied
+// headers/query params. Marshal or request-construction failures are
+// returned as *Error with ErrorKindInvalidRequest so callers see a uniform
+// failure shape regardless of which provider produced them.
+func (c providerClient) newJSONRequest(ctx context.Context, method, requestPath string, payload any, options requestOptions) (*http.Request, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &Error{
+			Kind:     ErrorKindInvalidRequest,
+			Provider: c.provider,
+			Err:      err,
+			Message:  fmt.Sprintf("marshal %s request: %v", c.provider, err),
+		}
+	}
+
+	requestURL := c.baseURL + requestPath
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, &Error{
+			Kind:     ErrorKindInvalidRequest,
+			Provider: c.provider,
+			Err:      err,
+			Message:  fmt.Sprintf("build %s request: %v", c.provider, err),
+		}
+	}
+	if len(options.Query) > 0 {
+		query := req.URL.Query()
+		for key, values := range options.Query {
+			for _, value := range values {
+				query.Add(key, value)
+			}
+		}
+		req.URL.RawQuery = query.Encode()
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range options.Headers {
+		req.Header.Set(key, value)
+	}
+
+	return req, nil
+}
+
+// do executes a prepared request and returns the body bytes alongside the
+// response. Transport-level failures (DNS, TCP, TLS, timeouts) are mapped
+// through classifyTransportError so callers can branch on ErrorKind
+// (e.g. ErrorKindTimeout) without inspecting raw network errors.
+func (c providerClient) do(req *http.Request) ([]byte, *http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, classifyTransportError(c.provider, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, &Error{
+			Kind:     ErrorKindInvalidResponse,
+			Provider: c.provider,
+			Err:      err,
+			Message:  fmt.Sprintf("read %s response: %v", c.provider, err),
+		}
+	}
+
+	return body, resp, nil
+}
+
+// normalizeBaseURL picks the caller-supplied base URL when set, otherwise
+// falls back to the adapter's default. Trailing slashes are trimmed so
+// adapters can safely concatenate a leading-slash request path.
+func normalizeBaseURL(baseURL, defaultBaseURL string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalized != "" {
+		return normalized
+	}
+	return defaultBaseURL
+}
+
+// validateStructuredSchema rejects obviously unusable Schema values before
+// they reach the provider, surfacing them as ErrorKindUnsupportedConfig.
+// A nil schema means "no structured output requested" and is accepted.
+func validateStructuredSchema(provider Provider, schema *Schema) error {
+	if schema == nil {
+		return nil
+	}
+	if len(schema.Value) == 0 {
+		return &Error{
+			Kind:     ErrorKindUnsupportedConfig,
+			Provider: provider,
+			Message:  "structured output schema is required when schema is provided",
+		}
+	}
+	if strings.TrimSpace(schema.Name) == "" {
+		return &Error{
+			Kind:     ErrorKindUnsupportedConfig,
+			Provider: provider,
+			Message:  "structured output schema name is required",
+		}
+	}
+	return nil
+}
+
+// parseStructuredOutput validates that a provider's structured-output
+// content is actually valid JSON and returns it as json.RawMessage for
+// callers to unmarshal into their own types. Invalid JSON becomes an
+// ErrorKindInvalidResponse so callers can distinguish provider hiccups
+// from caller-side parsing bugs.
+func parseStructuredOutput(provider Provider, content string) (json.RawMessage, error) {
+	trimmed := strings.TrimSpace(content)
+	raw := json.RawMessage(trimmed)
+	if !json.Valid(raw) {
+		return nil, &Error{
+			Kind:     ErrorKindInvalidResponse,
+			Provider: provider,
+			Message:  fmt.Sprintf("%s structured response was not valid JSON", provider),
+		}
+	}
+	return raw, nil
+}
+
+// firstNonEmpty returns the first non-blank string from values. Adapters
+// use it to prefer one source of a metadata field (e.g. an HTTP header)
+// over a fallback (e.g. a body field) without nested conditionals.
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -139,13 +139,6 @@ func validateStructuredSchema(provider Provider, schema *Schema) error {
 			Message:  "structured output schema is required when schema is provided",
 		}
 	}
-	if strings.TrimSpace(schema.Name) == "" {
-		return &Error{
-			Kind:     ErrorKindUnsupportedConfig,
-			Provider: provider,
-			Message:  "structured output schema name is required",
-		}
-	}
 	return nil
 }
 

--- a/ai/provider_test.go
+++ b/ai/provider_test.go
@@ -59,8 +59,8 @@ func TestValidateStructuredSchema(t *testing.T) {
 	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Name: "schema-without-body"}); err == nil {
 		t.Fatal("expected missing schema body error")
 	}
-	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Value: json.RawMessage(`{"type":"object"}`)}); err == nil {
-		t.Fatal("expected missing schema name error")
+	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Value: json.RawMessage(`{"type":"object"}`)}); err != nil {
+		t.Fatalf("unexpected error for nameless schema: %v", err)
 	}
 	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Name: "assessment_result", Value: json.RawMessage(`{"type":"object"}`)}); err != nil {
 		t.Fatalf("unexpected valid schema error: %v", err)
@@ -89,5 +89,23 @@ func TestParseStructuredOutput(t *testing.T) {
 	}
 	if !strings.Contains(aiErr.Error(), "openai structured response") {
 		t.Fatalf("unexpected error message: %s", aiErr.Error())
+	}
+}
+
+func TestClassifyTransportError_CanceledContextIsTimeout(t *testing.T) {
+	err := classifyTransportError(ProviderOpenAI, context.Canceled)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aiErr.Kind != ErrorKindTimeout {
+		t.Fatalf("unexpected error kind: %s", aiErr.Kind)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("expected wrapped context.Canceled")
 	}
 }

--- a/ai/provider_test.go
+++ b/ai/provider_test.go
@@ -91,21 +91,3 @@ func TestParseStructuredOutput(t *testing.T) {
 		t.Fatalf("unexpected error message: %s", aiErr.Error())
 	}
 }
-
-func TestClassifyTransportError_CanceledContextIsTimeout(t *testing.T) {
-	err := classifyTransportError(ProviderOpenAI, context.Canceled)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	var aiErr *Error
-	if !errors.As(err, &aiErr) {
-		t.Fatalf("expected *Error, got %T", err)
-	}
-	if aiErr.Kind != ErrorKindTimeout {
-		t.Fatalf("unexpected error kind: %s", aiErr.Kind)
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatal("expected wrapped context.Canceled")
-	}
-}

--- a/ai/provider_test.go
+++ b/ai/provider_test.go
@@ -1,0 +1,93 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProviderClientNewJSONRequest_AppliesOptions(t *testing.T) {
+	client := newProviderClient(ProviderOpenAI, Config{}, "https://example.com/v1")
+	req, err := client.newJSONRequest(
+		context.Background(),
+		http.MethodPost,
+		"/responses",
+		map[string]string{"prompt": "hello"},
+		requestOptions{
+			Headers: map[string]string{"Authorization": "Bearer test-key"},
+			Query:   url.Values{"key": []string{"abc123"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.URL.String() != "https://example.com/v1/responses?key=abc123" {
+		t.Fatalf("unexpected request URL: %s", req.URL.String())
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-key" {
+		t.Fatalf("unexpected authorization header: %s", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body["prompt"] != "hello" {
+		t.Fatalf("unexpected body content: %#v", body)
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	if got := normalizeBaseURL(" https://api.example.com/v1/ ", "https://default.example.com"); got != "https://api.example.com/v1" {
+		t.Fatalf("unexpected normalized url: %s", got)
+	}
+	if got := normalizeBaseURL("", "https://default.example.com"); got != "https://default.example.com" {
+		t.Fatalf("unexpected default url: %s", got)
+	}
+}
+
+func TestValidateStructuredSchema(t *testing.T) {
+	if err := validateStructuredSchema(ProviderOpenAI, nil); err != nil {
+		t.Fatalf("unexpected nil schema error: %v", err)
+	}
+	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Name: "schema-without-body"}); err == nil {
+		t.Fatal("expected missing schema body error")
+	}
+	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Value: json.RawMessage(`{"type":"object"}`)}); err == nil {
+		t.Fatal("expected missing schema name error")
+	}
+	if err := validateStructuredSchema(ProviderOpenAI, &Schema{Name: "assessment_result", Value: json.RawMessage(`{"type":"object"}`)}); err != nil {
+		t.Fatalf("unexpected valid schema error: %v", err)
+	}
+}
+
+func TestParseStructuredOutput(t *testing.T) {
+	raw, err := parseStructuredOutput(ProviderOpenAI, "  {\"verdict\":\"PASS\"}  ")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if string(raw) != `{"verdict":"PASS"}` {
+		t.Fatalf("unexpected parsed content: %s", raw)
+	}
+
+	_, err = parseStructuredOutput(ProviderOpenAI, "not-json")
+	if err == nil {
+		t.Fatal("expected invalid json error")
+	}
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aiErr.Kind != ErrorKindInvalidResponse {
+		t.Fatalf("unexpected error kind: %s", aiErr.Kind)
+	}
+	if !strings.Contains(aiErr.Error(), "openai structured response") {
+		t.Fatalf("unexpected error message: %s", aiErr.Error())
+	}
+}

--- a/ai/sdk_config.go
+++ b/ai/sdk_config.go
@@ -1,0 +1,57 @@
+package ai
+
+import (
+	"fmt"
+	"time"
+
+	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+)
+
+// NewClientFromConfig is the convenience entrypoint for callers that
+// already have an SDK config: it extracts the ai_* settings and, when
+// they are present, builds and returns a ready-to-use Client. When AI
+// is not configured it returns (nil, nil) so callers can treat AI as an
+// optional capability without special-casing the "not set" path.
+func NewClientFromConfig(config sdkconfig.Config) (Client, error) {
+	aiConfig, configured, err := ConfigFromSDKConfig(config)
+	if err != nil || !configured {
+		return nil, err
+	}
+
+	return NewClient(aiConfig)
+}
+
+// ConfigFromSDKConfig extracts AI settings from the SDK config vars
+// (ai_provider, ai_model, ai_api_key, ai_timeout, ai_max_tokens) into a
+// provider-neutral Config. The configured return value is false only
+// when none of the ai_* keys are set, letting callers distinguish
+// "intentionally disabled" from "misconfigured" (which is returned as a
+// non-nil error, e.g. an unparseable ai_timeout).
+func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
+	provider := Provider(config.GetString("ai_provider"))
+	model := config.GetString("ai_model")
+	apiKey := config.GetString("ai_api_key")
+	timeoutText := config.GetString("ai_timeout")
+	maxTokens := config.GetInt("ai_max_tokens")
+
+	if provider == "" && model == "" && apiKey == "" && timeoutText == "" && maxTokens == 0 {
+		return Config{}, false, nil
+	}
+
+	aiConfig := Config{
+		Provider:  provider,
+		Model:     model,
+		APIKey:    apiKey,
+		MaxTokens: maxTokens,
+	}
+
+	if timeoutText != "" {
+		timeout, err := time.ParseDuration(timeoutText)
+		if err != nil {
+			return Config{}, true, fmt.Errorf("invalid ai_timeout %q: %w", timeoutText, err)
+		}
+		aiConfig.Timeout = timeout
+	}
+
+	return aiConfig.normalized(), true, nil
+}

--- a/ai/sdk_config.go
+++ b/ai/sdk_config.go
@@ -22,7 +22,7 @@ func NewClientFromConfig(config sdkconfig.Config) (Client, error) {
 }
 
 // ConfigFromSDKConfig extracts AI settings from the SDK config vars
-// (ai_provider, ai_model, ai_api_key, ai_timeout, ai_max_tokens) into a
+// (ai_provider, ai_model, ai_api_key, ai_base_url, ai_timeout, ai_max_tokens) into a
 // provider-neutral Config. The configured return value is false only
 // when none of the ai_* keys are set, letting callers distinguish
 // "intentionally disabled" from "misconfigured" (which is returned as a
@@ -31,10 +31,11 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 	provider := Provider(config.GetString("ai_provider"))
 	model := config.GetString("ai_model")
 	apiKey := config.GetString("ai_api_key")
+	baseURL := config.GetString("ai_base_url")
 	timeoutText := config.GetString("ai_timeout")
 	maxTokens := config.GetInt("ai_max_tokens")
 
-	if provider == "" && model == "" && apiKey == "" && timeoutText == "" && maxTokens == 0 {
+	if provider == "" && model == "" && apiKey == "" && baseURL == "" && timeoutText == "" && maxTokens == 0 {
 		return Config{}, false, nil
 	}
 
@@ -42,6 +43,7 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 		Provider:  provider,
 		Model:     model,
 		APIKey:    apiKey,
+		BaseURL:   baseURL,
 		MaxTokens: maxTokens,
 	}
 

--- a/ai/sdk_config_test.go
+++ b/ai/sdk_config_test.go
@@ -22,6 +22,7 @@ func TestConfigFromSDKConfig_DefaultsAndParsing(t *testing.T) {
 		"ai_provider": "openai",
 		"ai_model":    "gpt-4o-mini",
 		"ai_api_key":  "test-key",
+		"ai_base_url": "http://127.0.0.1:8000/v1",
 		"ai_timeout":  "45s",
 	}})
 	if err != nil {
@@ -32,6 +33,9 @@ func TestConfigFromSDKConfig_DefaultsAndParsing(t *testing.T) {
 	}
 	if aiConfig.Provider != ProviderOpenAI {
 		t.Fatalf("unexpected provider: %s", aiConfig.Provider)
+	}
+	if aiConfig.BaseURL != "http://127.0.0.1:8000/v1" {
+		t.Fatalf("unexpected base URL: %q", aiConfig.BaseURL)
 	}
 	if aiConfig.Timeout != 45*time.Second {
 		t.Fatalf("unexpected timeout: %s", aiConfig.Timeout)

--- a/ai/sdk_config_test.go
+++ b/ai/sdk_config_test.go
@@ -1,0 +1,74 @@
+package ai
+
+import (
+	"testing"
+	"time"
+
+	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+)
+
+func TestConfigFromSDKConfig_NotConfigured(t *testing.T) {
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if configured {
+		t.Fatalf("expected unconfigured result, got configured with %#v", aiConfig)
+	}
+}
+
+func TestConfigFromSDKConfig_DefaultsAndParsing(t *testing.T) {
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_api_key":  "test-key",
+		"ai_timeout":  "45s",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result")
+	}
+	if aiConfig.Provider != ProviderOpenAI {
+		t.Fatalf("unexpected provider: %s", aiConfig.Provider)
+	}
+	if aiConfig.Timeout != 45*time.Second {
+		t.Fatalf("unexpected timeout: %s", aiConfig.Timeout)
+	}
+	if aiConfig.MaxTokens != defaultMaxTokens {
+		t.Fatalf("expected default max tokens %d, got %d", defaultMaxTokens, aiConfig.MaxTokens)
+	}
+}
+
+func TestConfigFromSDKConfig_InvalidTimeout(t *testing.T) {
+	_, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_api_key":  "test-key",
+		"ai_timeout":  "bad-timeout",
+	}})
+	if !configured {
+		t.Fatal("expected configured result for partial AI config")
+	}
+	if err == nil {
+		t.Fatal("expected invalid timeout error, got nil")
+	}
+}
+
+func TestNewClientFromConfig(t *testing.T) {
+	client, err := NewClientFromConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_api_key":  "test-key",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected configured client, got nil")
+	}
+	if _, ok := client.(*openAIClient); !ok {
+		t.Fatalf("expected *openAIClient, got %T", client)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,15 @@ const defaultServiceName = "overview"
 
 var allowedOutputTypes = []string{"json", "yaml", "sarif"}
 
+var inheritedTopLevelVarKeys = []string{
+	"ai_provider",
+	"ai_model",
+	"ai_api_key",
+	"ai_base_url",
+	"ai_timeout",
+	"ai_max_tokens",
+}
+
 // Config holds the configuration for a plugin execution.
 type Config struct {
 	ServiceName    string // Must be unique in the config file or logs will be overwritten
@@ -57,6 +66,17 @@ func NewConfig(requiredVars []string) Config {
 	for key, value := range localVars {
 		// Overwrite or add local vars onto the global vars
 		vars[key] = value
+	}
+	// AI settings may be declared at the top level so all services inherit them.
+	// Copy them into Vars so SDK consumers that only receive config.Config still
+	// see the same effective ai_* values at runtime.
+	for _, key := range inheritedTopLevelVarKeys {
+		if _, exists := vars[key]; exists {
+			continue
+		}
+		if value := viper.Get(key); value != nil {
+			vars[key] = value
+		}
 	}
 
 	topLoglevel := viper.GetString("loglevel")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -529,6 +529,7 @@ func TestSanitizeVars(t *testing.T) {
 		{"exact secret", "secret", "val", "REDACTED"},
 		{"exact apikey", "apikey", "val", "REDACTED"},
 		{"exact api_key", "api_key", "val", "REDACTED"},
+		{"exact ai_api_key", "ai_api_key", "val", "REDACTED"},
 
 		// Compound keys (new behavior)
 		{"compound clientsecret", "clientsecret", "val", "REDACTED"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -488,6 +488,44 @@ func TestNewConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestNewConfig_InheritsTopLevelAISettingsIntoVars(t *testing.T) {
+	viper.Reset()
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBufferString(`
+ai_provider: openai
+ai_model: gpt-5.4-mini
+ai_api_key: top-level-key
+ai_base_url: http://127.0.0.1:8000/v1
+ai_timeout: 45s
+ai_max_tokens: 1024
+services:
+  my-service-1:
+    policy:
+      catalogs:
+        - FINOS-CCC
+      applicability: ["tlp_green"]
+`))
+	if err != nil {
+		t.Fatalf("error reading config: %v", err)
+	}
+
+	viper.Set("service", "my-service-1")
+	c := NewConfig(nil)
+
+	for key, want := range map[string]interface{}{
+		"ai_provider":   "openai",
+		"ai_model":      "gpt-5.4-mini",
+		"ai_api_key":    "top-level-key",
+		"ai_base_url":   "http://127.0.0.1:8000/v1",
+		"ai_timeout":    "45s",
+		"ai_max_tokens": 1024,
+	} {
+		if got, ok := c.Vars[key]; !ok || got != want {
+			t.Fatalf("Vars[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+}
 func TestDefaultWritePath(t *testing.T) {
 	path := defaultWritePath()
 
@@ -666,11 +704,11 @@ func BenchmarkSanitizeVars(b *testing.B) {
 func TestSetupLoggingFilesAndDirectories(t *testing.T) {
 	tmpDir := path.Join(os.TempDir(), "privateer-test")
 	defer func() {
-	     err := os.RemoveAll(tmpDir)
-	     if err != nil {
-	         t.Error("Failed to clean up tmpDir")
-	     }
-	 }()
+		err := os.RemoveAll(tmpDir)
+		if err != nil {
+			t.Error("Failed to clean up tmpDir")
+		}
+	}()
 
 	logFilePath := path.Join(tmpDir, "test", "service.log")
 


### PR DESCRIPTION
Implements the first AI infrastructure slice from privateerproj/privateer-sdk#216.

- Adds an `ai` package with a provider-neutral `Client` interface exposing `Analyze(ctx, prompt, content, schema)`, plus shared request, schema, error, and response-metadata types.
- Adds an OpenAI adapter behind the shared interface (Chat Completions, Bearer auth, optional structured output via `response_format: json_schema`).
- Bridges the SDK config layer with `ai_provider`, `ai_model`, `ai_api_key`, `ai_timeout` (defaults 30s), and `ai_max_tokens` (defaults 256). AI is optional — when no `ai_*` keys are set, callers get `(nil, nil)`.
- Asserts `ai_api_key` is redacted by the existing config sanitizer (`config/config_test.go`).
- Adds focused unit tests covering request shaping, response parsing (text + JSON), timeout handling, and normalized error classification with a mock HTTP server.

Closes privateerproj/privateer-sdk#216.