### PR TITLE
feat: add gemara output format and configurable payload omission

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -36,6 +36,12 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("write", "", true, "Keep all of the detailed result outputs in a file. Disabling does not disable log files")
 	_ = viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
 
+	cmd.PersistentFlags().StringP("output", "o", "yaml", "Output format for results: yaml, json, sarif, or gemara")
+	_ = viper.BindPFlag("output", cmd.PersistentFlags().Lookup("output"))
+
+	cmd.PersistentFlags().BoolP("include-payload", "", false, "Include the raw evaluated payload in results output (large; useful for tracing)")
+	_ = viper.BindPFlag("include-payload", cmd.PersistentFlags().Lookup("include-payload"))
+
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ import (
 
 const defaultServiceName = "overview"
 
-var allowedOutputTypes = []string{"json", "yaml", "sarif"}
+var allowedOutputTypes = []string{"json", "yaml", "sarif", "gemara"}
 
 // Config holds the configuration for a plugin execution.
 type Config struct {
@@ -29,6 +29,7 @@ type Config struct {
 	Logger         hclog.Logger
 	Write          bool
 	Output         string
+	IncludePayload bool
 	WriteDirectory string
 	Invasive       bool
 	Policy         Policy
@@ -51,6 +52,7 @@ func NewConfig(requiredVars []string) Config {
 
 	write := viper.GetBool("write")                                         // defaults to true, but allow the user to disable file writing
 	output := strings.ToLower(strings.TrimSpace(viper.GetString("output"))) // defaults to yaml, but can be set to json
+	includePayload := viper.GetBool("include-payload")                      // defaults to false; payload is omitted unless explicitly requested
 
 	vars := viper.GetStringMap("vars")
 	localVars := viper.GetStringMap(fmt.Sprintf("services.%s.vars", serviceName))
@@ -108,7 +110,7 @@ func NewConfig(requiredVars []string) Config {
 	if output == "" {
 		output = "yaml"
 	} else if ok := slices.Contains(allowedOutputTypes, output); !ok {
-		errString = "bad output type, allowed output types are json or yaml"
+		errString = "bad output type, allowed output types are json, yaml, sarif, or gemara"
 	}
 
 	var err error
@@ -122,6 +124,7 @@ func NewConfig(requiredVars []string) Config {
 		WriteDirectory: writeDir,
 		Write:          write,
 		Output:         output,
+		IncludePayload: includePayload,
 		Invasive:       invasive,
 		Policy: Policy{
 			ControlCatalogs: catalogs,

--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,7 @@ func NewConfig(requiredVars []string) Config {
 	serviceName := viper.GetString("service") // the currently running service; if empty, we're probably running from core
 
 	write := viper.GetBool("write")                                         // defaults to true, but allow the user to disable file writing
-	output := strings.ToLower(strings.TrimSpace(viper.GetString("output"))) // defaults to yaml, but can be set to json
+	output := strings.ToLower(strings.TrimSpace(viper.GetString("output"))) // defaults to yaml; can be set to json, sarif, or gemara
 	includePayload := viper.GetBool("include-payload")                      // defaults to false; payload is omitted unless explicitly requested
 
 	vars := viper.GetStringMap("vars")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -329,7 +329,7 @@ services:
 		runningServiceName:   "my-service-1",
 		runningApplicability: []string{"tlp_green"},
 		requiredVars:         []string{},
-		expectedError:        "bad output type, allowed output types are json or yaml",
+		expectedError:        "bad output type, allowed output types are json, yaml, sarif, or gemara",
 		config: `
 output: bad
 services:
@@ -665,11 +665,11 @@ func BenchmarkSanitizeVars(b *testing.B) {
 func TestSetupLoggingFilesAndDirectories(t *testing.T) {
 	tmpDir := path.Join(os.TempDir(), "privateer-test")
 	defer func() {
-	     err := os.RemoveAll(tmpDir)
-	     if err != nil {
-	         t.Error("Failed to clean up tmpDir")
-	     }
-	 }()
+		err := os.RemoveAll(tmpDir)
+		if err != nil {
+			t.Error("Failed to clean up tmpDir")
+		}
+	}()
 
 	logFilePath := path.Join(tmpDir, "test", "service.log")
 

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/gemaraproj/go-gemara v0.4.0 h1:zyn7bJiqAitrRBCDlMYVLb8C1XhDWG2wI0j+pHad3HA=
-github.com/gemaraproj/go-gemara v0.4.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
 github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -18,12 +18,12 @@ import (
 
 // EvaluationOrchestrator gets the plugin in position to execute the specified evaluation suites.
 type EvaluationOrchestrator struct {
-	ServiceName       string             `yaml:"service-name"`
-	PluginName        string             `yaml:"plugin-name"`
-	PluginUri         string             `yaml:"plugin-uri"`
-	PluginVersion     string             `yaml:"plugin-version"`
-	Payload           any                `yaml:"payload,omitempty"`
-	Evaluation_Suites []*EvaluationSuite `yaml:"evaluation-suites"` // EvaluationSuite is a map of evaluations to their catalog names
+	ServiceName       string             `json:"service-name" yaml:"service-name"`
+	PluginName        string             `json:"plugin-name" yaml:"plugin-name"`
+	PluginUri         string             `json:"plugin-uri" yaml:"plugin-uri"`
+	PluginVersion     string             `json:"plugin-version" yaml:"plugin-version"`
+	Payload           any                `json:"payload,omitempty" yaml:"payload,omitempty"`
+	Evaluation_Suites []*EvaluationSuite `json:"evaluation-suites" yaml:"evaluation-suites"` // EvaluationSuite is a map of evaluations to their catalog names
 
 	possibleSuites    []*EvaluationSuite
 	possibleControls  map[string][]*gemara.Control
@@ -242,6 +242,16 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 // WriteResults writes the evaluation results to files in the configured output format.
 func (v *EvaluationOrchestrator) WriteResults() error {
 
+	// The payload is typically very large and is only useful for tracing.
+	// Omit it from results unless the user explicitly opts in via --include-payload.
+	// The omitempty struct tags then drop the field entirely from yaml/json.
+	if !v.config.IncludePayload {
+		v.Payload = nil
+		for _, suite := range v.Evaluation_Suites {
+			suite.payload = nil
+		}
+	}
+
 	var err error
 	var result []byte
 	switch v.config.Output {
@@ -251,6 +261,13 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 	case "yaml":
 		result, err = yaml.Marshal(v)
 		err = errMod(err, "wr20")
+	case "gemara":
+		// Emit gemara-native EvaluationLog objects so results are directly
+		// consumable by the wider gemara ecosystem. One log per suite is
+		// produced; unlike the default formats this does not wrap them in
+		// Privateer's orchestrator envelope.
+		result, err = v.marshalGemara()
+		err = errMod(err, "wr25")
 	case "sarif":
 		// Use "README.md" as artifactURI for repository-level assessments
 		// GitHub Code Scanning requires PhysicalLocation, and "README.md" is a common file path
@@ -264,7 +281,7 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 			result = append(result, sarifBytes...)
 		}
 	default:
-		err = fmt.Errorf("output type '%s' is not supported. Supported types are 'json', 'yaml', and 'sarif'", v.config.Output)
+		err = fmt.Errorf("output type '%s' is not supported. Supported types are 'json', 'yaml', 'sarif', and 'gemara'", v.config.Output)
 		err = errMod(err, "wr30")
 	}
 	if err != nil {
@@ -278,7 +295,27 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 	return nil
 }
 
+// marshalGemara serializes the run as gemara-native EvaluationLog objects.
+// Each evaluation suite contributes one EvaluationLog. A single suite is
+// emitted as a lone document; multiple suites are emitted as a list so the
+// output remains valid for downstream gemara consumers.
+func (v *EvaluationOrchestrator) marshalGemara() ([]byte, error) {
+	logs := make([]gemara.EvaluationLog, 0, len(v.Evaluation_Suites))
+	for _, suite := range v.Evaluation_Suites {
+		logs = append(logs, suite.EvaluationLog)
+	}
+	if len(logs) == 1 {
+		return yaml.Marshal(logs[0])
+	}
+	return yaml.Marshal(logs)
+}
+
 func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result []byte, extension string) error {
+	// gemara output is YAML-encoded; write it with a .yaml extension
+	// rather than a literal ".gemara" so tooling recognizes the format.
+	if extension == "gemara" {
+		extension = "yaml"
+	}
 	if !strings.Contains(extension, ".") {
 		extension = fmt.Sprintf(".%s", extension)
 	}

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -242,14 +242,16 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 // WriteResults writes the evaluation results to files in the configured output format.
 func (v *EvaluationOrchestrator) WriteResults() error {
 
-	// The payload is typically very large and is only useful for tracing.
+	// The orchestrator's Payload is typically very large and is only useful for tracing.
 	// Omit it from results unless the user explicitly opts in via --include-payload.
-	// The omitempty struct tags then drop the field entirely from yaml/json.
+	// The omitempty struct tag on Payload then drops the field entirely from yaml/json.
+	// EvaluationSuite.payload is unexported and not serialized, so no per-suite cleanup is needed.
+	// Snapshot-and-restore keeps WriteResults idempotent: callers that invoke it more than once,
+	// or that inspect the orchestrator afterwards, still see the original payload.
 	if !v.config.IncludePayload {
+		saved := v.Payload
 		v.Payload = nil
-		for _, suite := range v.Evaluation_Suites {
-			suite.payload = nil
-		}
+		defer func() { v.Payload = saved }()
 	}
 
 	var err error
@@ -296,16 +298,12 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 }
 
 // marshalGemara serializes the run as gemara-native EvaluationLog objects.
-// Each evaluation suite contributes one EvaluationLog. A single suite is
-// emitted as a lone document; multiple suites are emitted as a list so the
-// output remains valid for downstream gemara consumers.
+// Each evaluation suite contributes one EvaluationLog. Output is always a list,
+// even for a single suite, so downstream gemara consumers can parse uniformly.
 func (v *EvaluationOrchestrator) marshalGemara() ([]byte, error) {
 	logs := make([]gemara.EvaluationLog, 0, len(v.Evaluation_Suites))
 	for _, suite := range v.Evaluation_Suites {
 		logs = append(logs, suite.EvaluationLog)
-	}
-	if len(logs) == 1 {
-		return yaml.Marshal(logs[0])
 	}
 	return yaml.Marshal(logs)
 }

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -3,10 +3,12 @@ package pluginkit
 import (
 	"embed"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/goccy/go-yaml"
 	"github.com/privateerproj/privateer-sdk/config"
 )
 
@@ -612,6 +614,179 @@ func TestEvaluationOrchestrator_WriteResults_SARIF(t *testing.T) {
 		err = orchestrator.WriteResults()
 		if err != nil {
 			t.Errorf("WriteResults failed: %v", err)
+		}
+	})
+}
+
+// writeResultsFixture builds a minimal orchestrator with one suite, writes
+// results to a temp directory, and returns the path to the produced file.
+// It centralizes the boilerplate shared by the gemara and IncludePayload
+// tests below.
+func writeResultsFixture(t *testing.T, output string, includePayload bool, payload any) string {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "test-writeresults-")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	cfg := setBasicConfig()
+	cfg.Output = output
+	cfg.Write = true
+	cfg.WriteDirectory = tmpDir
+	cfg.IncludePayload = includePayload
+
+	orchestrator := &EvaluationOrchestrator{
+		ServiceName:   "test-service",
+		PluginName:    "test-plugin",
+		PluginUri:     "https://github.com/test/repo",
+		PluginVersion: "1.0.0",
+		Payload:       payload,
+		config:        cfg,
+	}
+	orchestrator.Evaluation_Suites = []*EvaluationSuite{
+		{
+			CatalogId:     "test-catalog",
+			EvaluationLog: createTestEvalLog(),
+			config:        cfg,
+		},
+	}
+
+	if err := orchestrator.WriteResults(); err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// gemara output is written with a .yaml extension; everything else uses the
+	// configured output name directly.
+	ext := output
+	if ext == "gemara" {
+		ext = "yaml"
+	}
+	return filepath.Join(tmpDir, "test-service", "test-service."+ext)
+}
+
+func TestEvaluationOrchestrator_WriteResults_Gemara(t *testing.T) {
+	t.Run("emits a list of EvaluationLog objects", func(t *testing.T) {
+		resultPath := writeResultsFixture(t, "gemara", false, nil)
+
+		data, err := os.ReadFile(resultPath)
+		if err != nil {
+			t.Fatalf("expected gemara output file at %s: %v", resultPath, err)
+		}
+
+		// Always-list shape: downstream consumers can range over the result
+		// without first checking whether they got a mapping or a sequence.
+		var logs []gemara.EvaluationLog
+		if err := yaml.Unmarshal(data, &logs); err != nil {
+			t.Fatalf("gemara output is not a list of EvaluationLog: %v\noutput was:\n%s", err, data)
+		}
+		if len(logs) != 1 {
+			t.Errorf("expected 1 EvaluationLog (one suite), got %d", len(logs))
+		}
+
+		// The gemara branch must not wrap output in the orchestrator envelope.
+		if strings.Contains(string(data), "service-name") || strings.Contains(string(data), "plugin-name") {
+			t.Errorf("gemara output should not contain orchestrator envelope fields, got:\n%s", data)
+		}
+	})
+
+	t.Run("empty suite list still emits a list, not null", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "test-writeresults-")
+		if err != nil {
+			t.Fatalf("temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+		cfg := setBasicConfig()
+		cfg.Output = "gemara"
+		cfg.Write = true
+		cfg.WriteDirectory = tmpDir
+
+		orchestrator := &EvaluationOrchestrator{
+			ServiceName: "test-service",
+			PluginName:  "test-plugin",
+			config:      cfg,
+		}
+		if err := orchestrator.WriteResults(); err != nil {
+			t.Fatalf("WriteResults failed: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "test-service", "test-service.yaml"))
+		if err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		if strings.TrimSpace(string(data)) != "[]" {
+			t.Errorf("expected empty list output, got: %q", strings.TrimSpace(string(data)))
+		}
+	})
+}
+
+func TestEvaluationOrchestrator_WriteResults_IncludePayload(t *testing.T) {
+	type orchestratorOutput struct {
+		Payload any `yaml:"payload"`
+	}
+
+	largePayload := map[string]any{"trace": "details", "size": "large"}
+
+	t.Run("payload is omitted by default", func(t *testing.T) {
+		resultPath := writeResultsFixture(t, "yaml", false, largePayload)
+
+		data, err := os.ReadFile(resultPath)
+		if err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		if strings.Contains(string(data), "payload:") {
+			t.Errorf("payload should be omitted by default, but found 'payload:' in output:\n%s", data)
+		}
+	})
+
+	t.Run("payload is included when IncludePayload is true", func(t *testing.T) {
+		resultPath := writeResultsFixture(t, "yaml", true, largePayload)
+
+		data, err := os.ReadFile(resultPath)
+		if err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		var out orchestratorOutput
+		if err := yaml.Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal output: %v", err)
+		}
+		if out.Payload == nil {
+			t.Errorf("payload should be present when IncludePayload=true, got nil in output:\n%s", data)
+		}
+	})
+
+	t.Run("orchestrator Payload is restored after WriteResults", func(t *testing.T) {
+		// Verifies the snapshot-and-restore: calling WriteResults must not
+		// permanently mutate v.Payload, so repeated calls and post-write
+		// inspection behave consistently.
+		tmpDir, err := os.MkdirTemp("", "test-writeresults-")
+		if err != nil {
+			t.Fatalf("temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+		cfg := setBasicConfig()
+		cfg.Output = "yaml"
+		cfg.Write = true
+		cfg.WriteDirectory = tmpDir
+		cfg.IncludePayload = false
+
+		orchestrator := &EvaluationOrchestrator{
+			ServiceName: "test-service",
+			PluginName:  "test-plugin",
+			Payload:     largePayload,
+			config:      cfg,
+		}
+		orchestrator.Evaluation_Suites = []*EvaluationSuite{
+			{CatalogId: "test-catalog", EvaluationLog: createTestEvalLog(), config: cfg},
+		}
+
+		if err := orchestrator.WriteResults(); err != nil {
+			t.Fatalf("WriteResults failed: %v", err)
+		}
+		if orchestrator.Payload == nil {
+			t.Errorf("WriteResults must not permanently null out Payload; second-call inspections would be wrong")
 		}
 	})
 }

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -676,12 +676,23 @@ func TestEvaluationOrchestrator_WriteResults_Gemara(t *testing.T) {
 
 		// Always-list shape: downstream consumers can range over the result
 		// without first checking whether they got a mapping or a sequence.
-		var logs []gemara.EvaluationLog
+		// Unmarshal into a generic list rather than []gemara.EvaluationLog so
+		// the shape assertion does not depend on gemara's strict field
+		// validation (which rejects unset enum defaults in test fixtures).
+		var logs []map[string]any
 		if err := yaml.Unmarshal(data, &logs); err != nil {
-			t.Fatalf("gemara output is not a list of EvaluationLog: %v\noutput was:\n%s", err, data)
+			t.Fatalf("gemara output is not a list: %v\noutput was:\n%s", err, data)
 		}
 		if len(logs) != 1 {
 			t.Errorf("expected 1 EvaluationLog (one suite), got %d", len(logs))
+		}
+		// Verify it really is the gemara shape (has metadata + evaluations
+		// at the top level of each entry) rather than the orchestrator envelope.
+		if _, ok := logs[0]["metadata"]; !ok {
+			t.Errorf("expected gemara EvaluationLog shape with 'metadata' key, got: %v", logs[0])
+		}
+		if _, ok := logs[0]["evaluations"]; !ok {
+			t.Errorf("expected gemara EvaluationLog shape with 'evaluations' key, got: %v", logs[0])
 		}
 
 		// The gemara branch must not wrap output in the orchestrator envelope.
@@ -715,6 +726,8 @@ func TestEvaluationOrchestrator_WriteResults_Gemara(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read output: %v", err)
 		}
+		// Expect "[]" — a valid empty sequence — rather than null, so consumers
+		// don't have to special-case the no-suites condition.
 		if strings.TrimSpace(string(data)) != "[]" {
 			t.Errorf("expected empty list output, got: %q", strings.TrimSpace(string(data)))
 		}

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -14,23 +14,23 @@ type TestSet func() (result gemara.ControlEvaluation)
 // EvaluationSuite contains the results of all EvaluationLog executions.
 // Exported fields will be used in the final YAML or JSON output documents.
 type EvaluationSuite struct {
-	Name   string        // Name is the name of the suite
-	Result gemara.Result // Result is Passed if all evaluations in the suite passed
+	Name   string        `json:"name" yaml:"name"`     // Name is the name of the suite
+	Result gemara.Result `json:"result" yaml:"result"` // Result is Passed if all evaluations in the suite passed
 
-	CatalogId string `yaml:"catalog-id"` // CatalogId associates this suite with a catalog
-	StartTime string `yaml:"start-time"` // StartTime is the time the plugin started
-	EndTime   string `yaml:"end-time"`   // EndTime is the time the plugin ended
+	CatalogId string `json:"catalog-id" yaml:"catalog-id"` // CatalogId associates this suite with a catalog
+	StartTime string `json:"start-time" yaml:"start-time"` // StartTime is the time the plugin started
+	EndTime   string `json:"end-time" yaml:"end-time"`     // EndTime is the time the plugin ended
 
-	CorruptedState bool `yaml:"corrupted-state"` // CorruptedState is true if any testSet failed to revert at the end of the evaluation
+	CorruptedState bool `json:"corrupted-state" yaml:"corrupted-state"` // CorruptedState is true if any testSet failed to revert at the end of the evaluation
 
-	EvaluationLog gemara.EvaluationLog `yaml:"control-evaluations"` // EvaluationLog is a slice of evaluations to be executed
+	EvaluationLog gemara.EvaluationLog `json:"control-evaluations" yaml:"control-evaluations"` // EvaluationLog is a slice of evaluations to be executed
 
 	config *config.Config // config is the global configuration
 
 	payload       interface{}                        // payload is the data to be evaluated
 	loader        DataLoader                         // loader is the function to load the payload
 	changeManager *ChangeManager                     // changes is a list of changes made during the evaluation
-	catalog       *gemara.ControlCatalog                    // The Catalog this evaluation suite references
+	catalog       *gemara.ControlCatalog             // The Catalog this evaluation suite references
 	steps         map[string][]gemara.AssessmentStep // steps is a map of control IDs to their assessment steps
 
 	evalSuccesses int // successes is the number of successful evaluations


### PR DESCRIPTION
This pr omits the large payload from results by default (--include-payload to keep it) and adds a non-breaking gemara output format that emits gemara-native EvaluationLog objects. Also adds --output/-o and --include-payload CLI flags and fixes the stale output-type validation message.

refers: https://github.com/privateerproj/privateer/issues/65 | https://github.com/privateerproj/privateer/issues/172

```
When everything is battoned down, it is time to run forth.

Usage:
  pvtr run [flags]

Global Flags:
  -b, --binaries-path string     Path to the directory where plugins are installed (default "C:\\Users\\Lucy\\.privateer\\bin")
  -c, --config string            Configuration file, JSON or YAML (if omitted, falls back to ./config.yml then ~/.privateer/config.yml)
  -h, --help                     Give me a heading! Help for the specified command
      --include-payload          Include the raw evaluated payload in results output (large; useful for tracing)
  -l, --loglevel string          Log level (trace, debug, info, warn, error, off) (default "error")
  -o, --output string            Output format for results: yaml, json, sarif, or gemara (default "yaml")
  -s, --service string           Named service to execute from the config
      --silent                   Only show essential log information
  -t, --test-suites string       Named set of test sets to execute from the plugin (default "default")
      --write                    Keep all of the detailed result outputs in a file. Disabling does not disable log files (default true)
  -w, --write-directory string   Directory to write evaluation results to (default "evaluation_results")``` 