### PR TITLE
fix(deps): bump go-gemara to 0.5.0 and adapt to API changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/privateerproj/privateer-sdk
 go 1.26.2
 
 require (
-	github.com/gemaraproj/go-gemara v0.4.0
+	github.com/gemaraproj/go-gemara v0.5.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gemaraproj/go-gemara v0.4.0 h1:zyn7bJiqAitrRBCDlMYVLb8C1XhDWG2wI0j+pHad3HA=
 github.com/gemaraproj/go-gemara v0.4.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
+github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -252,12 +252,9 @@ func (v *EvaluationOrchestrator) WriteResults() error {
 		result, err = yaml.Marshal(v)
 		err = errMod(err, "wr20")
 	case "sarif":
-		// Use "README.md" as artifactURI for repository-level assessments
-		// GitHub Code Scanning requires PhysicalLocation, and "README.md" is a common file path
-		// that satisfies this requirement (as recommended in gemara's ToSARIF documentation)
 		for _, suite := range v.Evaluation_Suites {
-			evalConverter := gemaraconv.EvaluationLog(&suite.EvaluationLog)
-			sarifBytes, sarifErr := evalConverter.ToSARIF("", suite.catalog)
+			evalConverter := gemaraconv.EvaluationLog(suite.EvaluationLog)
+			sarifBytes, sarifErr := evalConverter.ToSARIF(gemaraconv.WithCatalog(suite.catalog))
 			if sarifErr != nil {
 				break
 			}

--- a/pluginkit/evaluation_orchestrator_test.go
+++ b/pluginkit/evaluation_orchestrator_test.go
@@ -2,7 +2,9 @@ package pluginkit
 
 import (
 	"embed"
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -543,75 +545,96 @@ func BenchmarkGetPluginCatalogs(b *testing.B) {
 }
 
 func TestEvaluationOrchestrator_WriteResults_SARIF(t *testing.T) {
-	t.Run("SARIF output with PluginUri", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "test-sarif-")
-		if err != nil {
-			t.Fatalf("Failed to create temp directory: %v", err)
-		}
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
+	tests := []struct {
+		name      string
+		pluginUri string
+		catalog   *gemara.ControlCatalog
+	}{
+		{name: "with PluginUri, no catalog", pluginUri: "https://github.com/test/repo"},
+		{name: "without PluginUri, no catalog", pluginUri: ""},
+		{name: "with catalog enrichment", pluginUri: "https://github.com/test/repo", catalog: getTestCatalogWithRequirements()},
+	}
 
-		cfg := setBasicConfig()
-		cfg.Output = "sarif"
-		cfg.Write = true
-		cfg.WriteDirectory = tmpDir
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "test-sarif-")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer func() {
+				_ = os.RemoveAll(tmpDir)
+			}()
 
-		orchestrator := &EvaluationOrchestrator{
-			ServiceName:   "test-service",
-			PluginName:    "test-plugin",
-			PluginUri:     "https://github.com/test/repo",
-			PluginVersion: "1.0.0",
-			config:        cfg,
-		}
+			cfg := setBasicConfig()
+			cfg.Output = "sarif"
+			cfg.Write = true
+			cfg.WriteDirectory = tmpDir
 
-		suite := &EvaluationSuite{
-			CatalogId:     "test-catalog",
-			EvaluationLog: createTestEvalLog(),
-			config:        cfg,
-		}
+			orchestrator := &EvaluationOrchestrator{
+				ServiceName:   "test-service",
+				PluginName:    "test-plugin",
+				PluginUri:     tc.pluginUri,
+				PluginVersion: "1.0.0",
+				config:        cfg,
+			}
 
-		orchestrator.Evaluation_Suites = []*EvaluationSuite{suite}
+			suite := &EvaluationSuite{
+				CatalogId:     "test-catalog",
+				EvaluationLog: createTestEvalLog(),
+				catalog:       tc.catalog,
+				config:        cfg,
+			}
 
-		err = orchestrator.WriteResults()
-		if err != nil {
-			t.Errorf("WriteResults failed: %v", err)
-		}
-	})
+			orchestrator.Evaluation_Suites = []*EvaluationSuite{suite}
 
-	t.Run("SARIF output without PluginUri", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "test-sarif-")
-		if err != nil {
-			t.Fatalf("Failed to create temp directory: %v", err)
-		}
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
+			if err := orchestrator.WriteResults(); err != nil {
+				t.Fatalf("WriteResults failed: %v", err)
+			}
 
-		cfg := setBasicConfig()
-		cfg.Output = "sarif"
-		cfg.Write = true
-		cfg.WriteDirectory = tmpDir
+			outPath := filepath.Join(tmpDir, "test-service", "test-service.sarif")
+			data, err := os.ReadFile(outPath)
+			if err != nil {
+				t.Fatalf("expected SARIF output at %s: %v", outPath, err)
+			}
+			if len(data) == 0 {
+				t.Fatal("SARIF output file is empty")
+			}
 
-		orchestrator := &EvaluationOrchestrator{
-			ServiceName:   "test-service",
-			PluginName:    "test-plugin",
-			PluginUri:     "",
-			PluginVersion: "1.0.0",
-			config:        cfg,
-		}
-
-		suite := &EvaluationSuite{
-			CatalogId:     "test-catalog",
-			EvaluationLog: createTestEvalLog(),
-			config:        cfg,
-		}
-
-		orchestrator.Evaluation_Suites = []*EvaluationSuite{suite}
-
-		err = orchestrator.WriteResults()
-		if err != nil {
-			t.Errorf("WriteResults failed: %v", err)
-		}
-	})
+			var report struct {
+				Schema  string `json:"$schema"`
+				Version string `json:"version"`
+				Runs    []struct {
+					Tool struct {
+						Driver struct {
+							Name           string `json:"name"`
+							InformationURI string `json:"informationUri"`
+							Version        string `json:"version"`
+							Rules          []struct {
+								ID string `json:"id"`
+							} `json:"rules"`
+						} `json:"driver"`
+					} `json:"tool"`
+				} `json:"runs"`
+			}
+			if err := json.Unmarshal(data, &report); err != nil {
+				t.Fatalf("SARIF output is not valid JSON: %v", err)
+			}
+			if report.Version != "2.1.0" {
+				t.Errorf("expected SARIF version 2.1.0, got %q", report.Version)
+			}
+			if !strings.Contains(report.Schema, "sarif-schema-2.1.0") {
+				t.Errorf("unexpected SARIF schema: %q", report.Schema)
+			}
+			if len(report.Runs) == 0 {
+				t.Fatal("expected at least one SARIF run")
+			}
+			driver := report.Runs[0].Tool.Driver
+			if driver.Name != "test-plugin" {
+				t.Errorf("expected driver name %q, got %q", "test-plugin", driver.Name)
+			}
+			if driver.InformationURI != "https://github.com/test/repo" {
+				t.Errorf("expected driver informationUri from EvaluationLog metadata, got %q", driver.InformationURI)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What

Bump `github.com/gemaraproj/go-gemara` from 0.4.0 to 0.5.0 and update the single SARIF call site in `pluginkit/evaluation_orchestrator.go` to match the new `gemaraconv` API. Also strengthens the existing SARIF tests with content assertions and adds a catalog-enrichment case.

## Why

gemara 0.5.0 introduced two breaking changes that block compilation: `gemaraconv.EvaluationLog` now takes a value instead of a pointer, and `ToSARIF` switched from positional `(artifactURI, catalog)` args to variadic `EvalOption` functional options. The existing SARIF tests only asserted that `WriteResults` returned `nil`, so the new API path needed real content verification to catch future regressions. Supersedes #221.

## Notes

The stale "Use README.md as artifactURI" comment block was removed because PR #141 (`fix: Remove artifactURI usage from SARIF output`) deliberately removed that wiring. Keeping the comment without the code created a false contract.

The new SARIF tests assert version `2.1.0`, schema URL, driver `name`, and driver `informationUri`. The driver fields come from `EvaluationLog.Metadata.Author`, which is hard-coded in `createTestEvalLog()`. They do not come from `orchestrator.PluginUri` because the tests bypass `Evaluate` (which would overwrite metadata) and call `WriteResults` directly. Reviewers: the two "with/without PluginUri" subtests therefore produce identical output. They are preserved for parity with the prior tests but are effectively the same scenario.

The third subtest (`with catalog enrichment`) is the only one that exercises the `gemaraconv.WithCatalog` path. If `findControlAndRequirement` ever changes shape, that case will catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)