### PR TITLE
feat(ai): add AI dry-run mode and SDK config integration

### DIFF
--- a/ai/client.go
+++ b/ai/client.go
@@ -28,6 +28,11 @@ const (
 const (
 	defaultTimeout   = 30 * time.Second
 	defaultMaxTokens = 256
+
+	// FinishReasonDryRun is the predictable FinishReason returned by
+	// the dry-run client so callers can distinguish a dry-run result
+	// from any real provider response.
+	FinishReasonDryRun = "dry_run"
 )
 
 // clientFactory builds a provider adapter from a normalized Config. Each
@@ -73,6 +78,10 @@ type Config struct {
 	// HTTPClient lets callers inject a custom transport (e.g. for tests or
 	// instrumentation). When nil, a client honoring Timeout is constructed.
 	HTTPClient *http.Client
+	// DryRun routes Analyze through a logging-only client that never
+	// contacts the provider. Useful for inspecting prompts and model
+	// settings without spending tokens or needing real credentials.
+	DryRun bool
 }
 
 // Schema tells the provider to return a structured JSON answer instead of
@@ -169,16 +178,25 @@ type ResponseMetadata struct {
 
 // NewClient creates a provider-specific AI client from provider-neutral
 // configuration. It validates the config, then dispatches to the adapter
-// registered for config.Provider.
+// registered for config.Provider. When config.DryRun is set, a logging-only
+// client is returned that never contacts the provider.
 func NewClient(config Config) (Client, error) {
 	config = config.normalized()
 	if err := config.validate(); err != nil {
 		return nil, err
 	}
 
+	// The provider must be registered even in dry-run mode so typos surface
+	// here instead of later when the user switches to a live run.
 	factory, ok := clientFactories[config.Provider]
 	if !ok {
 		return nil, fmt.Errorf("unsupported ai provider %q", config.Provider)
+	}
+
+	// Dry-run short-circuits the factory: return a logging-only client
+	// that never contacts the provider.
+	if config.DryRun {
+		return newDryRunClient(config), nil
 	}
 
 	return factory(config), nil
@@ -188,11 +206,13 @@ func (c Config) validate() error {
 	if strings.TrimSpace(string(c.Provider)) == "" {
 		return fmt.Errorf("ai provider is required")
 	}
-	if strings.TrimSpace(c.APIKey) == "" {
-		return fmt.Errorf("ai api key is required")
-	}
 	if strings.TrimSpace(c.Model) == "" {
 		return fmt.Errorf("ai model is required")
+	}
+	// API key is only required for live provider calls. Dry-run mode lets
+	// operators preview prompts without provisioning credentials.
+	if !c.DryRun && strings.TrimSpace(c.APIKey) == "" {
+		return fmt.Errorf("ai api key is required")
 	}
 	return nil
 }

--- a/ai/client.go
+++ b/ai/client.go
@@ -54,6 +54,16 @@ type Client interface {
 	Analyze(ctx context.Context, prompt, content string, schema *Schema) (*AnalyzeResponse, error)
 }
 
+// requestValidator is implemented by adapters that can reject a malformed
+// request (prompt, content, schema) without contacting the provider. Live
+// Analyze and the dry-run client both call it before any provider-specific
+// work, so dry-run rejects exactly the requests a live run would — including
+// any provider-specific validation rules that do not belong in the
+// package-level validateStructuredSchema.
+type requestValidator interface {
+	ValidateRequest(prompt, content string, schema *Schema) error
+}
+
 // Config holds the provider-neutral settings used to construct any adapter.
 // Provider-specific concerns (auth header shape, endpoint paths, request body
 // schema) are the adapter's responsibility, not this struct's.

--- a/ai/dryrun.go
+++ b/ai/dryrun.go
@@ -12,13 +12,27 @@ import (
 // inspect prompt content and model settings without spending tokens.
 type dryRunClient struct {
 	config Config
+	// validator runs the target provider's request validation so dry-run
+	// rejects the same malformed requests a live run would, including
+	// provider-specific rules. Nil when the provider exposes no validator.
+	validator requestValidator
 	// logOutput lets tests capture log output. When nil, log.Default()
 	// is used so dry-run details appear on the standard logger.
 	logOutput io.Writer
 }
 
 func newDryRunClient(config Config) *dryRunClient {
-	return &dryRunClient{config: config}
+	// Build the real adapter (a cheap struct construction, no network) purely
+	// to borrow its request validation, so dry-run mirrors the provider the
+	// caller would hit live. NewClient already rejects unregistered providers
+	// before reaching here.
+	var validator requestValidator
+	if factory, ok := clientFactories[config.Provider]; ok {
+		if v, ok := factory(config).(requestValidator); ok {
+			validator = v
+		}
+	}
+	return &dryRunClient{config: config, validator: validator}
 }
 
 // Analyze records prompt details and returns a dry-run result without
@@ -29,10 +43,14 @@ func (c *dryRunClient) Analyze(ctx context.Context, prompt, content string, sche
 		return nil, err
 	}
 
-	// Run the same schema validation a live adapter would, so a malformed
-	// schema (e.g. missing Value) fails here instead of slipping through
-	// dry-run only to break when the user switches to a live run.
-	if err := validateStructuredSchema(c.config.Provider, schema); err != nil {
+	// Run the target provider's validation (falling back to the package-level
+	// schema check) so a malformed request fails here instead of slipping
+	// through dry-run only to break when the user switches to a live run.
+	if c.validator != nil {
+		if err := c.validator.ValidateRequest(prompt, content, schema); err != nil {
+			return nil, err
+		}
+	} else if err := validateStructuredSchema(c.config.Provider, schema); err != nil {
 		return nil, err
 	}
 

--- a/ai/dryrun.go
+++ b/ai/dryrun.go
@@ -1,0 +1,68 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+)
+
+// dryRunClient implements Client without contacting any provider. It logs
+// what would be sent and returns a predictable response so callers can
+// inspect prompt content and model settings without spending tokens.
+type dryRunClient struct {
+	config Config
+	// logOutput lets tests capture log output. When nil, log.Default()
+	// is used so dry-run details appear on the standard logger.
+	logOutput io.Writer
+}
+
+func newDryRunClient(config Config) *dryRunClient {
+	return &dryRunClient{config: config}
+}
+
+// Analyze records prompt details and returns a dry-run result without
+// making any network call. Callers can distinguish dry-run responses via
+// Metadata.FinishReason == FinishReasonDryRun.
+func (c *dryRunClient) Analyze(ctx context.Context, prompt, content string, schema *Schema) (*AnalyzeResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Run the same schema validation a live adapter would, so a malformed
+	// schema (e.g. missing Value) fails here instead of slipping through
+	// dry-run only to break when the user switches to a live run.
+	if err := validateStructuredSchema(c.config.Provider, schema); err != nil {
+		return nil, err
+	}
+
+	schemaName := "<none>"
+	if schema != nil {
+		schemaName = schema.Name
+	}
+
+	summary := fmt.Sprintf(
+		"[ai dry-run] provider=%s model=%s max_tokens=%d schema=%s prompt_bytes=%d content_bytes=%d",
+		c.config.Provider, c.config.Model, c.config.MaxTokens, schemaName, len(prompt), len(content),
+	)
+	c.logf("%s", summary)
+	c.logf("[ai dry-run] prompt: %s", prompt)
+	c.logf("[ai dry-run] content: %s", content)
+
+	return &AnalyzeResponse{
+		Text: summary,
+		Metadata: ResponseMetadata{
+			Provider:     c.config.Provider,
+			Model:        c.config.Model,
+			FinishReason: FinishReasonDryRun,
+		},
+	}, nil
+}
+
+func (c *dryRunClient) logf(format string, args ...any) {
+	if c.logOutput != nil {
+		_, _ = fmt.Fprintf(c.logOutput, format+"\n", args...)
+		return
+	}
+	log.Printf(format, args...)
+}

--- a/ai/dryrun_test.go
+++ b/ai/dryrun_test.go
@@ -166,12 +166,15 @@ func TestNewClient_DryRunFalseReturnsRealAdapter(t *testing.T) {
 }
 
 func TestDryRunAnalyze_RejectsInvalidSchema(t *testing.T) {
-	// Malformed schemas (e.g. missing Value) should fail in dry-run with
-	// the same error a live adapter would return, so callers don't
-	// discover the typo only after switching off dry-run.
+	// Malformed schemas should fail in dry-run with the same error a live
+	// adapter would return, so callers don't discover the typo only after
+	// switching off dry-run. This covers both the package-level check
+	// (missing Value) and the OpenAI-specific rule (missing Name), which
+	// dry-run reaches by delegating to the provider's ValidateRequest.
 	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini"})
 	cases := map[string]*Schema{
 		"missing Value": {Name: "foo"},
+		"missing Name":  {Value: json.RawMessage(`{"type":"object"}`)},
 	}
 	for name, schema := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/ai/dryrun_test.go
+++ b/ai/dryrun_test.go
@@ -1,0 +1,188 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewClient_DryRunReturnsDryRunClient(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		Model:    "gpt-4o-mini",
+		DryRun:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := client.(*dryRunClient); !ok {
+		t.Fatalf("expected *dryRunClient, got %T", client)
+	}
+}
+
+func TestNewClient_DryRunDoesNotRequireAPIKey(t *testing.T) {
+	if _, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		Model:    "gpt-4o-mini",
+		DryRun:   true,
+	}); err != nil {
+		t.Fatalf("expected dry-run to succeed without api key, got: %v", err)
+	}
+}
+
+func TestNewClient_DryRunStillRequiresProviderAndModel(t *testing.T) {
+	if _, err := NewClient(Config{DryRun: true, Model: "gpt-4o-mini"}); err == nil {
+		t.Fatal("expected error when provider missing in dry-run, got nil")
+	}
+	if _, err := NewClient(Config{DryRun: true, Provider: ProviderOpenAI}); err == nil {
+		t.Fatal("expected error when model missing in dry-run, got nil")
+	}
+}
+
+func TestNewClient_DryRunRejectsUnsupportedProvider(t *testing.T) {
+	// Typos should surface in dry-run mode too, so users don't discover them
+	// only after switching to a live run.
+	_, err := NewClient(Config{
+		Provider: "totally-bogus",
+		Model:    "gpt-4o-mini",
+		DryRun:   true,
+	})
+	if err == nil {
+		t.Fatal("expected unsupported-provider error in dry-run, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported ai provider") {
+		t.Fatalf("expected unsupported-provider error, got: %v", err)
+	}
+}
+
+func TestDryRunAnalyze_ReturnsSentinelMetadata(t *testing.T) {
+	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini", MaxTokens: 256})
+	var buf bytes.Buffer
+	client.logOutput = &buf
+
+	resp, err := client.Analyze(context.Background(), "what is 2+2?", "context-doc", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Metadata.FinishReason != FinishReasonDryRun {
+		t.Fatalf("expected FinishReason %q, got %q", FinishReasonDryRun, resp.Metadata.FinishReason)
+	}
+	if resp.Metadata.Provider != ProviderOpenAI {
+		t.Fatalf("expected provider %q, got %q", ProviderOpenAI, resp.Metadata.Provider)
+	}
+	if resp.Metadata.Model != "gpt-4o-mini" {
+		t.Fatalf("expected model gpt-4o-mini, got %q", resp.Metadata.Model)
+	}
+	if !strings.Contains(resp.Text, "[ai dry-run]") {
+		t.Fatalf("expected dry-run marker in Text, got %q", resp.Text)
+	}
+}
+
+func TestDryRunAnalyze_LogsPromptDetails(t *testing.T) {
+	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini", MaxTokens: 128})
+	var buf bytes.Buffer
+	client.logOutput = &buf
+
+	schema := &Schema{Name: "verdict", Value: json.RawMessage(`{"type":"object"}`)}
+	if _, err := client.Analyze(context.Background(), "PROMPT-X", "CONTENT-Y", schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logged := buf.String()
+	for _, want := range []string{"PROMPT-X", "CONTENT-Y", "gpt-4o-mini", "openai", "max_tokens=128", "schema=verdict"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("expected log output to contain %q; got:\n%s", want, logged)
+		}
+	}
+}
+
+func TestDryRunAnalyze_MakesNoHTTPCall(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		Model:    "gpt-4o-mini",
+		DryRun:   true,
+		BaseURL:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := client.Analyze(context.Background(), "p", "c", nil); err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	if called {
+		t.Fatal("dry-run should not make any HTTP request")
+	}
+}
+
+func TestDryRunAnalyze_RespectsCancelledContext(t *testing.T) {
+	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := client.Analyze(ctx, "p", "c", nil); err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+}
+
+func TestDryRunAnalyze_LogsNoSchemaAsPlaceholder(t *testing.T) {
+	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini"})
+	var buf bytes.Buffer
+	client.logOutput = &buf
+
+	if _, err := client.Analyze(context.Background(), "p", "c", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "schema=<none>") {
+		t.Errorf("expected 'schema=<none>' in log output, got:\n%s", buf.String())
+	}
+}
+
+func TestNewClient_DryRunFalseReturnsRealAdapter(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: ProviderOpenAI,
+		Model:    "gpt-4o-mini",
+		APIKey:   "test-key",
+		// DryRun left at zero value (false).
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := client.(*dryRunClient); ok {
+		t.Fatal("expected real adapter when DryRun=false, got *dryRunClient")
+	}
+	if _, ok := client.(*openAIClient); !ok {
+		t.Fatalf("expected *openAIClient when DryRun=false, got %T", client)
+	}
+}
+
+func TestDryRunAnalyze_RejectsInvalidSchema(t *testing.T) {
+	// Malformed schemas (e.g. missing Value) should fail in dry-run with
+	// the same error a live adapter would return, so callers don't
+	// discover the typo only after switching off dry-run.
+	client := newDryRunClient(Config{Provider: ProviderOpenAI, Model: "gpt-4o-mini"})
+	cases := map[string]*Schema{
+		"missing Value": {Name: "foo"},
+	}
+	for name, schema := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := client.Analyze(context.Background(), "p", "c", schema)
+			if err == nil {
+				t.Fatal("expected schema-validation error in dry-run, got nil")
+			}
+			var aiErr *Error
+			if !errors.As(err, &aiErr) || aiErr.Kind != ErrorKindUnsupportedConfig {
+				t.Fatalf("expected ErrorKindUnsupportedConfig, got %v", err)
+			}
+		})
+	}
+}

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -77,10 +77,29 @@ func newOpenAIClient(config Config) *openAIClient {
 	}
 }
 
+// ValidateRequest rejects malformed requests before any network call,
+// applying both the package-level schema checks and OpenAI-specific rules
+// (a structured-output schema must carry a Name, which OpenAI requires as
+// the json_schema wrapper label). Live Analyze and the dry-run client both
+// call this so a request that would fail live also fails in dry-run.
+func (c *openAIClient) ValidateRequest(prompt, content string, schema *Schema) error {
+	if err := validateStructuredSchema(ProviderOpenAI, schema); err != nil {
+		return err
+	}
+	if schema != nil && strings.TrimSpace(schema.Name) == "" {
+		return &Error{
+			Kind:     ErrorKindUnsupportedConfig,
+			Provider: ProviderOpenAI,
+			Message:  "structured output schema name is required",
+		}
+	}
+	return nil
+}
+
 // Analyze implements the Client contract against OpenAI Chat Completions.
-// At a high level it: validates the optional Schema, builds the request
-// body (translating Schema into OpenAI's response_format when present),
-// POSTs to /chat/completions with a Bearer token, returns non-200
+// At a high level it: validates the request via ValidateRequest, builds the
+// request body (translating Schema into OpenAI's response_format when
+// present), POSTs to /chat/completions with a Bearer token, returns non-200
 // responses as classified *Error values, and finally maps the first
 // choice back into a provider-neutral AnalyzeResponse (parsing the
 // content as JSON when a schema was requested).
@@ -90,15 +109,8 @@ func (c *openAIClient) Analyze(ctx context.Context, prompt, content string, sche
 		Content: content,
 		Schema:  schema,
 	}
-	if err := validateStructuredSchema(ProviderOpenAI, request.Schema); err != nil {
+	if err := c.ValidateRequest(request.Prompt, request.Content, request.Schema); err != nil {
 		return nil, err
-	}
-	if request.Schema != nil && strings.TrimSpace(request.Schema.Name) == "" {
-		return nil, &Error{
-			Kind:     ErrorKindUnsupportedConfig,
-			Provider: ProviderOpenAI,
-			Message:  "structured output schema name is required",
-		}
 	}
 
 	reqBody := openAIChatCompletionsRequest{

--- a/ai/sdk_config.go
+++ b/ai/sdk_config.go
@@ -2,9 +2,11 @@ package ai
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+	"github.com/spf13/viper"
 )
 
 // NewClientFromConfig is the convenience entrypoint for callers that
@@ -22,20 +24,24 @@ func NewClientFromConfig(config sdkconfig.Config) (Client, error) {
 }
 
 // ConfigFromSDKConfig extracts AI settings from the SDK config vars
-// (ai_provider, ai_model, ai_api_key, ai_base_url, ai_timeout, ai_max_tokens) into a
-// provider-neutral Config. The configured return value is false only
-// when none of the ai_* keys are set, letting callers distinguish
-// "intentionally disabled" from "misconfigured" (which is returned as a
-// non-nil error, e.g. an unparseable ai_timeout).
+// (ai_provider, ai_model, ai_api_key, ai_base_url, ai_timeout, ai_max_tokens,
+// ai_dry_run) and the --dry-run-ai CLI flag into a provider-neutral Config. The
+// configured return value is false only when none of these inputs are set,
+// letting callers distinguish "intentionally disabled" from "misconfigured"
+// (which is returned as a non-nil error, e.g. an unparseable ai_timeout).
 func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
-	provider := Provider(config.GetString("ai_provider"))
-	model := config.GetString("ai_model")
-	apiKey := config.GetString("ai_api_key")
-	baseURL := config.GetString("ai_base_url")
-	timeoutText := config.GetString("ai_timeout")
-	maxTokens := config.GetInt("ai_max_tokens")
+	provider := Provider(getSDKConfigString(config, "ai_provider"))
+	model := getSDKConfigString(config, "ai_model")
+	apiKey := getSDKConfigString(config, "ai_api_key")
+	baseURL := getSDKConfigString(config, "ai_base_url")
+	timeoutText := getSDKConfigString(config, "ai_timeout")
+	maxTokens := getSDKConfigInt(config, "ai_max_tokens")
+	// Dry-run is enabled by either the config-driven key (for non-CLI
+	// consumers and YAML configs) or the CLI flag (bound to viper in
+	// command.SetBase). Both sources are checked so either path works.
+	dryRun := getSDKConfigBool(config, "ai_dry_run") || viper.GetBool("dry-run-ai")
 
-	if provider == "" && model == "" && apiKey == "" && baseURL == "" && timeoutText == "" && maxTokens == 0 {
+	if provider == "" && model == "" && apiKey == "" && baseURL == "" && timeoutText == "" && maxTokens == 0 && !dryRun {
 		return Config{}, false, nil
 	}
 
@@ -45,6 +51,7 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 		APIKey:    apiKey,
 		BaseURL:   baseURL,
 		MaxTokens: maxTokens,
+		DryRun:    dryRun,
 	}
 
 	if timeoutText != "" {
@@ -56,4 +63,25 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 	}
 
 	return aiConfig.normalized(), true, nil
+}
+
+func getSDKConfigString(config sdkconfig.Config, key string) string {
+	if value := strings.TrimSpace(config.GetString(key)); value != "" {
+		return value
+	}
+	return strings.TrimSpace(viper.GetString(key))
+}
+
+func getSDKConfigInt(config sdkconfig.Config, key string) int {
+	if value := config.GetInt(key); value != 0 {
+		return value
+	}
+	return viper.GetInt(key)
+}
+
+func getSDKConfigBool(config sdkconfig.Config, key string) bool {
+	if value := config.GetBool(key); value {
+		return true
+	}
+	return viper.GetBool(key)
 }

--- a/ai/sdk_config.go
+++ b/ai/sdk_config.go
@@ -30,16 +30,40 @@ func NewClientFromConfig(config sdkconfig.Config) (Client, error) {
 // letting callers distinguish "intentionally disabled" from "misconfigured"
 // (which is returned as a non-nil error, e.g. an unparseable ai_timeout).
 func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
-	provider := Provider(getSDKConfigString(config, "ai_provider"))
-	model := getSDKConfigString(config, "ai_model")
-	apiKey := getSDKConfigString(config, "ai_api_key")
-	baseURL := getSDKConfigString(config, "ai_base_url")
-	timeoutText := getSDKConfigString(config, "ai_timeout")
-	maxTokens := getSDKConfigInt(config, "ai_max_tokens")
+	providerText, err := getSDKConfigString(config, "ai_provider")
+	if err != nil {
+		return Config{}, true, err
+	}
+	provider := Provider(providerText)
+	model, err := getSDKConfigString(config, "ai_model")
+	if err != nil {
+		return Config{}, true, err
+	}
+	apiKey, err := getSDKConfigString(config, "ai_api_key")
+	if err != nil {
+		return Config{}, true, err
+	}
+	baseURL, err := getSDKConfigString(config, "ai_base_url")
+	if err != nil {
+		return Config{}, true, err
+	}
+	timeoutText, err := getSDKConfigString(config, "ai_timeout")
+	if err != nil {
+		return Config{}, true, err
+	}
+	maxTokens, err := getSDKConfigInt(config, "ai_max_tokens")
+	if err != nil {
+		return Config{}, true, err
+	}
 	// ai_dry_run is one logical key fed by config Vars, top-level YAML/env, and
 	// the --dry-run-ai CLI flag (bound to ai_dry_run in command.SetBase).
-	dryRun := getSDKConfigBool(config, "ai_dry_run")
+	dryRun, err := getSDKConfigBool(config, "ai_dry_run")
+	if err != nil {
+		return Config{}, true, err
+	}
 
+	// Dry-run by itself is treated as AI configuration so provider/model
+	// validation fails early instead of being deferred to first use.
 	if provider == "" && model == "" && apiKey == "" && baseURL == "" && timeoutText == "" && maxTokens == 0 && !dryRun {
 		return Config{}, false, nil
 	}
@@ -64,35 +88,50 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 	return aiConfig.normalized(), true, nil
 }
 
-func getSDKConfigString(config sdkconfig.Config, key string) string {
-	if value := strings.TrimSpace(config.GetString(key)); value != "" {
-		return value
+// getSDKConfigString resolves on key presence, not value, so an explicit empty
+// string in per-service Vars is honored instead of falling through to viper.
+// A present non-string value is treated as misconfigured AI input.
+func getSDKConfigString(config sdkconfig.Config, key string) (string, error) {
+	value, valType := config.GetVar(key)
+	switch valType {
+	case "missing":
+		return strings.TrimSpace(viper.GetString(key)), nil
+	case "string":
+		return strings.TrimSpace(value.(string)), nil
+	default:
+		return "", fmt.Errorf("%s must be a string, got %s", key, valType)
 	}
-	return strings.TrimSpace(viper.GetString(key))
 }
 
-// getSDKConfigInt resolves on key *presence*, not on the zero value, so an
-// explicit 0 is honored rather than treated as "unset". Per-service config
-// Vars win when the key is present as an int; otherwise viper (global YAML,
-// env, CLI flags) is consulted when it has the key set; absent everywhere it
-// returns 0. This keeps the helper reusable for future int knobs where 0 is a
-// meaningful value (e.g. 0 retries, 0 = no cap) without a silent viper inherit.
-func getSDKConfigInt(config sdkconfig.Config, key string) int {
-	if _, valType := config.GetVar(key); valType == "int" {
-		return config.GetInt(key)
+// getSDKConfigInt resolves on key presence, not value, so an explicit 0 in
+// per-service Vars is honored instead of falling through to viper. A present
+// non-int value is treated as misconfigured AI input.
+func getSDKConfigInt(config sdkconfig.Config, key string) (int, error) {
+	value, valType := config.GetVar(key)
+	switch valType {
+	case "missing":
+		if viper.IsSet(key) {
+			return viper.GetInt(key), nil
+		}
+		return 0, nil
+	case "int":
+		return value.(int), nil
+	default:
+		return 0, fmt.Errorf("%s must be an int, got %s", key, valType)
 	}
-	if viper.IsSet(key) {
-		return viper.GetInt(key)
-	}
-	return 0
 }
 
-// getSDKConfigBool returns true when the key is truthy in per-service config
-// Vars or, failing that, in viper (global YAML, env, and bound CLI flags). Any
-// truthy source wins; absent everywhere it returns false.
-func getSDKConfigBool(config sdkconfig.Config, key string) bool {
-	if value := config.GetBool(key); value {
-		return true
+// getSDKConfigBool resolves on key presence, not value, so an explicit false in
+// per-service Vars is honored instead of falling through to viper. A present
+// non-bool value is treated as misconfigured AI input.
+func getSDKConfigBool(config sdkconfig.Config, key string) (bool, error) {
+	value, valType := config.GetVar(key)
+	switch valType {
+	case "missing":
+		return viper.GetBool(key), nil
+	case "bool":
+		return value.(bool), nil
+	default:
+		return false, fmt.Errorf("%s must be a bool, got %s", key, valType)
 	}
-	return viper.GetBool(key)
 }

--- a/ai/sdk_config.go
+++ b/ai/sdk_config.go
@@ -36,10 +36,9 @@ func ConfigFromSDKConfig(config sdkconfig.Config) (Config, bool, error) {
 	baseURL := getSDKConfigString(config, "ai_base_url")
 	timeoutText := getSDKConfigString(config, "ai_timeout")
 	maxTokens := getSDKConfigInt(config, "ai_max_tokens")
-	// Dry-run is enabled by either the config-driven key (for non-CLI
-	// consumers and YAML configs) or the CLI flag (bound to viper in
-	// command.SetBase). Both sources are checked so either path works.
-	dryRun := getSDKConfigBool(config, "ai_dry_run") || viper.GetBool("dry-run-ai")
+	// ai_dry_run is one logical key fed by config Vars, top-level YAML/env, and
+	// the --dry-run-ai CLI flag (bound to ai_dry_run in command.SetBase).
+	dryRun := getSDKConfigBool(config, "ai_dry_run")
 
 	if provider == "" && model == "" && apiKey == "" && baseURL == "" && timeoutText == "" && maxTokens == 0 && !dryRun {
 		return Config{}, false, nil
@@ -72,13 +71,25 @@ func getSDKConfigString(config sdkconfig.Config, key string) string {
 	return strings.TrimSpace(viper.GetString(key))
 }
 
+// getSDKConfigInt resolves on key *presence*, not on the zero value, so an
+// explicit 0 is honored rather than treated as "unset". Per-service config
+// Vars win when the key is present as an int; otherwise viper (global YAML,
+// env, CLI flags) is consulted when it has the key set; absent everywhere it
+// returns 0. This keeps the helper reusable for future int knobs where 0 is a
+// meaningful value (e.g. 0 retries, 0 = no cap) without a silent viper inherit.
 func getSDKConfigInt(config sdkconfig.Config, key string) int {
-	if value := config.GetInt(key); value != 0 {
-		return value
+	if _, valType := config.GetVar(key); valType == "int" {
+		return config.GetInt(key)
 	}
-	return viper.GetInt(key)
+	if viper.IsSet(key) {
+		return viper.GetInt(key)
+	}
+	return 0
 }
 
+// getSDKConfigBool returns true when the key is truthy in per-service config
+// Vars or, failing that, in viper (global YAML, env, and bound CLI flags). Any
+// truthy source wins; absent everywhere it returns false.
 func getSDKConfigBool(config sdkconfig.Config, key string) bool {
 	if value := config.GetBool(key); value {
 		return true

--- a/ai/sdk_config_test.go
+++ b/ai/sdk_config_test.go
@@ -1,10 +1,12 @@
 package ai
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+	"github.com/spf13/viper"
 )
 
 func TestConfigFromSDKConfig_NotConfigured(t *testing.T) {
@@ -74,5 +76,165 @@ func TestNewClientFromConfig(t *testing.T) {
 	}
 	if _, ok := client.(*openAIClient); !ok {
 		t.Fatalf("expected *openAIClient, got %T", client)
+	}
+}
+
+func TestNewClientFromConfig_PartialLiveConfigErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		vars        map[string]interface{}
+		wantErrText string
+	}{
+		{
+			name: "provider only",
+			vars: map[string]interface{}{
+				"ai_provider": "openai",
+			},
+			wantErrText: "ai model is required",
+		},
+		{
+			name: "model only",
+			vars: map[string]interface{}{
+				"ai_model": "gpt-4o-mini",
+			},
+			wantErrText: "ai provider is required",
+		},
+		{
+			name: "provider and model without api key",
+			vars: map[string]interface{}{
+				"ai_provider": "openai",
+				"ai_model":    "gpt-4o-mini",
+			},
+			wantErrText: "ai api key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			client, err := NewClientFromConfig(sdkconfig.Config{Vars: tt.vars})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrText)
+			}
+			if client != nil {
+				t.Fatalf("expected nil client, got %T", client)
+			}
+		})
+	}
+}
+
+func TestConfigFromSDKConfig_DryRunViaConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_dry_run":  true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result")
+	}
+	if !aiConfig.DryRun {
+		t.Fatal("expected DryRun to be true")
+	}
+}
+
+func TestConfigFromSDKConfig_DryRunViaCLIFlag(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("dry-run-ai", true)
+
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result")
+	}
+	if !aiConfig.DryRun {
+		t.Fatal("expected DryRun to be true from CLI flag")
+	}
+}
+
+func TestNewClientFromConfig_DryRunSkipsAPIKey(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	client, err := NewClientFromConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_dry_run":  true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := client.(*dryRunClient); !ok {
+		t.Fatalf("expected *dryRunClient, got %T", client)
+	}
+}
+
+func TestConfigFromSDKConfig_DryRunDefaultsFalse(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_api_key":  "test-key",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result")
+	}
+	if aiConfig.DryRun {
+		t.Fatal("expected DryRun to default to false when neither config var nor flag is set")
+	}
+}
+
+func TestConfigFromSDKConfig_UsesViperFallback(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("ai_provider", "openai")
+	viper.Set("ai_model", "gpt-4o-mini")
+	viper.Set("ai_api_key", "test-key")
+	viper.Set("ai_timeout", "45s")
+	viper.Set("ai_max_tokens", 512)
+
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result from viper-backed settings")
+	}
+	if aiConfig.Provider != ProviderOpenAI {
+		t.Fatalf("unexpected provider: %s", aiConfig.Provider)
+	}
+	if aiConfig.Model != "gpt-4o-mini" {
+		t.Fatalf("unexpected model: %s", aiConfig.Model)
+	}
+	if aiConfig.APIKey != "test-key" {
+		t.Fatalf("unexpected api key: %s", aiConfig.APIKey)
+	}
+	if aiConfig.Timeout != 45*time.Second {
+		t.Fatalf("unexpected timeout: %s", aiConfig.Timeout)
+	}
+	if aiConfig.MaxTokens != 512 {
+		t.Fatalf("unexpected max tokens: %d", aiConfig.MaxTokens)
 	}
 }

--- a/ai/sdk_config_test.go
+++ b/ai/sdk_config_test.go
@@ -151,7 +151,10 @@ func TestConfigFromSDKConfig_DryRunViaConfig(t *testing.T) {
 func TestConfigFromSDKConfig_DryRunViaCLIFlag(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
-	viper.Set("dry-run-ai", true)
+	// The --dry-run-ai flag binds to the ai_dry_run viper key in
+	// command.SetBase (verified in command/base_test.go); here we set that
+	// resolved key directly to confirm ConfigFromSDKConfig reads it.
+	viper.Set("ai_dry_run", true)
 
 	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
 		"ai_provider": "openai",
@@ -237,4 +240,49 @@ func TestConfigFromSDKConfig_UsesViperFallback(t *testing.T) {
 	if aiConfig.MaxTokens != 512 {
 		t.Fatalf("unexpected max tokens: %d", aiConfig.MaxTokens)
 	}
+}
+
+func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
+	t.Run("explicit zero in config Vars is honored over viper", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+		viper.Set("ai_retries", 5)
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{"ai_retries": 0}}
+		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+			t.Fatalf("expected explicit 0 from config Vars, got %d", got)
+		}
+	})
+
+	t.Run("falls through to viper when absent from config Vars", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+		viper.Set("ai_retries", 5)
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{}}
+		if got := getSDKConfigInt(config, "ai_retries"); got != 5 {
+			t.Fatalf("expected viper fallback 5, got %d", got)
+		}
+	})
+
+	t.Run("explicit zero in viper is honored when set", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+		viper.Set("ai_retries", 0)
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{}}
+		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+			t.Fatalf("expected explicit viper 0, got %d", got)
+		}
+	})
+
+	t.Run("returns 0 when unset everywhere", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{}}
+		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+			t.Fatalf("expected 0 when unset, got %d", got)
+		}
+	})
 }

--- a/ai/sdk_config_test.go
+++ b/ai/sdk_config_test.go
@@ -194,6 +194,28 @@ func TestConfigFromSDKConfig_DryRunViaEnv(t *testing.T) {
 	}
 }
 
+func TestConfigFromSDKConfig_DryRunConfigFalseOverridesViperTrue(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("ai_dry_run", true)
+
+	aiConfig, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: map[string]interface{}{
+		"ai_provider": "openai",
+		"ai_model":    "gpt-4o-mini",
+		"ai_api_key":  "test-key",
+		"ai_dry_run":  false,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !configured {
+		t.Fatal("expected configured result")
+	}
+	if aiConfig.DryRun {
+		t.Fatal("expected explicit ai_dry_run=false in config Vars to override viper true")
+	}
+}
+
 func TestNewClientFromConfig_DryRunSkipsAPIKey(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
@@ -265,6 +287,92 @@ func TestConfigFromSDKConfig_UsesViperFallback(t *testing.T) {
 	}
 }
 
+func TestConfigFromSDKConfig_RejectsWrongTypedVars(t *testing.T) {
+	tests := []struct {
+		name        string
+		vars        map[string]interface{}
+		wantErrText string
+	}{
+		{
+			name: "string field with int value",
+			vars: map[string]interface{}{
+				"ai_provider": 123,
+			},
+			wantErrText: "ai_provider must be a string, got int",
+		},
+		{
+			name: "int field with string value",
+			vars: map[string]interface{}{
+				"ai_provider":   "openai",
+				"ai_model":      "gpt-4o-mini",
+				"ai_api_key":    "test-key",
+				"ai_max_tokens": "512",
+			},
+			wantErrText: "ai_max_tokens must be an int, got string",
+		},
+		{
+			name: "bool field with string value",
+			vars: map[string]interface{}{
+				"ai_provider": "openai",
+				"ai_model":    "gpt-4o-mini",
+				"ai_api_key":  "test-key",
+				"ai_dry_run":  "true",
+			},
+			wantErrText: "ai_dry_run must be a bool, got string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			_, configured, err := ConfigFromSDKConfig(sdkconfig.Config{Vars: tt.vars})
+			if !configured {
+				t.Fatal("expected configured result for wrong-typed AI config")
+			}
+			if err == nil {
+				t.Fatal("expected wrong-type error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrText)
+			}
+		})
+	}
+}
+
+func TestGetSDKConfigString_ResolvesOnPresence(t *testing.T) {
+	t.Run("explicit empty string in config Vars is honored over viper", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+		viper.Set("ai_base_url", "http://127.0.0.1:8000/v1")
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{"ai_base_url": ""}}
+		got, err := getSDKConfigString(config, "ai_base_url")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("expected explicit empty string from config Vars, got %q", got)
+		}
+	})
+
+	t.Run("falls through to viper when absent from config Vars", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+		viper.Set("ai_base_url", "http://127.0.0.1:8000/v1")
+
+		config := sdkconfig.Config{Vars: map[string]interface{}{}}
+		got, err := getSDKConfigString(config, "ai_base_url")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "http://127.0.0.1:8000/v1" {
+			t.Fatalf("expected viper fallback base URL, got %q", got)
+		}
+	})
+}
+
 func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
 	t.Run("explicit zero in config Vars is honored over viper", func(t *testing.T) {
 		viper.Reset()
@@ -272,7 +380,11 @@ func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
 		viper.Set("ai_retries", 5)
 
 		config := sdkconfig.Config{Vars: map[string]interface{}{"ai_retries": 0}}
-		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+		got, err := getSDKConfigInt(config, "ai_retries")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
 			t.Fatalf("expected explicit 0 from config Vars, got %d", got)
 		}
 	})
@@ -283,7 +395,11 @@ func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
 		viper.Set("ai_retries", 5)
 
 		config := sdkconfig.Config{Vars: map[string]interface{}{}}
-		if got := getSDKConfigInt(config, "ai_retries"); got != 5 {
+		got, err := getSDKConfigInt(config, "ai_retries")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 5 {
 			t.Fatalf("expected viper fallback 5, got %d", got)
 		}
 	})
@@ -294,7 +410,11 @@ func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
 		viper.Set("ai_retries", 0)
 
 		config := sdkconfig.Config{Vars: map[string]interface{}{}}
-		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+		got, err := getSDKConfigInt(config, "ai_retries")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
 			t.Fatalf("expected explicit viper 0, got %d", got)
 		}
 	})
@@ -304,7 +424,11 @@ func TestGetSDKConfigInt_ResolvesOnPresence(t *testing.T) {
 		t.Cleanup(viper.Reset)
 
 		config := sdkconfig.Config{Vars: map[string]interface{}{}}
-		if got := getSDKConfigInt(config, "ai_retries"); got != 0 {
+		got, err := getSDKConfigInt(config, "ai_retries")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
 			t.Fatalf("expected 0 when unset, got %d", got)
 		}
 	})

--- a/command/base.go
+++ b/command/base.go
@@ -36,6 +36,9 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("write", "", true, "Keep all of the detailed result outputs in a file. Disabling does not disable log files")
 	_ = viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
 
+	cmd.PersistentFlags().Bool("dry-run-ai", false, "Log AI prompts and model settings without making real provider requests")
+	_ = viper.BindPFlag("dry-run-ai", cmd.PersistentFlags().Lookup("dry-run-ai"))
+
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }
 

--- a/command/base.go
+++ b/command/base.go
@@ -36,8 +36,12 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("write", "", true, "Keep all of the detailed result outputs in a file. Disabling does not disable log files")
 	_ = viper.BindPFlag("write", cmd.PersistentFlags().Lookup("write"))
 
+	// User-facing flag stays --dry-run-ai, but it is bound to the ai_dry_run
+	// viper key so the CLI flag joins env (PVTR_AI_DRY_RUN) and YAML config,
+	// which already use that key, on a single logical key. Callers read only
+	// ai_dry_run.
 	cmd.PersistentFlags().Bool("dry-run-ai", false, "Log AI prompts and model settings without making real provider requests")
-	_ = viper.BindPFlag("dry-run-ai", cmd.PersistentFlags().Lookup("dry-run-ai"))
+	_ = viper.BindPFlag("ai_dry_run", cmd.PersistentFlags().Lookup("dry-run-ai"))
 
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -39,6 +39,26 @@ func TestSetBase_ConfigFlagDefaultIsEmpty(t *testing.T) {
 	}
 }
 
+func TestSetBase_DryRunAIFlag(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "test"}
+	SetBase(cmd)
+
+	flag := cmd.PersistentFlags().Lookup("dry-run-ai")
+	if flag == nil {
+		t.Fatal("expected dry-run-ai flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("expected dry-run-ai default to be 'false', got %q", flag.DefValue)
+	}
+	if err := cmd.PersistentFlags().Set("dry-run-ai", "true"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+	if !viper.GetBool("dry-run-ai") {
+		t.Error("expected viper to reflect dry-run-ai=true after flag set")
+	}
+}
+
 func TestReadConfig_ExplicitConfigPath(t *testing.T) {
 	resetViper()
 

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -54,8 +54,9 @@ func TestSetBase_DryRunAIFlag(t *testing.T) {
 	if err := cmd.PersistentFlags().Set("dry-run-ai", "true"); err != nil {
 		t.Fatalf("failed to set flag: %v", err)
 	}
-	if !viper.GetBool("dry-run-ai") {
-		t.Error("expected viper to reflect dry-run-ai=true after flag set")
+	// The flag is bound to the ai_dry_run viper key, not "dry-run-ai".
+	if !viper.GetBool("ai_dry_run") {
+		t.Error("expected viper ai_dry_run=true after --dry-run-ai flag set")
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ var inheritedTopLevelVarKeys = []string{
 	"ai_base_url",
 	"ai_timeout",
 	"ai_max_tokens",
+	"ai_dry_run",
 }
 
 // Config holds the configuration for a plugin execution.
@@ -76,7 +77,8 @@ func NewConfig(requiredVars []string) Config {
 		if _, exists := vars[key]; exists {
 			continue
 		}
-		if value := viper.Get(key); value != nil {
+		if viper.IsSet(key) {
+			value := viper.Get(key)
 			vars[key] = value
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -515,6 +516,7 @@ ai_api_key: top-level-key
 ai_base_url: http://127.0.0.1:8000/v1
 ai_timeout: 45s
 ai_max_tokens: 1024
+ai_dry_run: true
 services:
   my-service-1:
     policy:
@@ -536,12 +538,31 @@ services:
 		"ai_base_url":   "http://127.0.0.1:8000/v1",
 		"ai_timeout":    "45s",
 		"ai_max_tokens": 1024,
+		"ai_dry_run":    true,
 	} {
 		if got, ok := c.Vars[key]; !ok || got != want {
 			t.Fatalf("Vars[%q] = %#v, want %#v", key, got, want)
 		}
 	}
 }
+
+func TestNewConfig_DoesNotInheritBoundFlagDefaultIntoVars(t *testing.T) {
+	viper.Reset()
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("dry-run-ai", false, "")
+	if err := viper.BindPFlag("ai_dry_run", flags.Lookup("dry-run-ai")); err != nil {
+		t.Fatalf("failed to bind dry-run flag: %v", err)
+	}
+	viper.Set("service", "my-service-1")
+	viper.Set("services.my-service-1.policy.catalogs", []string{"FINOS-CCC"})
+	viper.Set("services.my-service-1.policy.applicability", []string{"tlp_green"})
+
+	c := NewConfig(nil)
+	if got, ok := c.Vars["ai_dry_run"]; ok {
+		t.Fatalf("did not expect bound flag default to be inherited into Vars, got %#v", got)
+	}
+}
+
 func TestDefaultWritePath(t *testing.T) {
 	path := defaultWritePath()
 


### PR DESCRIPTION
## What

Adds an AI **dry-run mode**: callers can inspect prompts, model settings, and structured-output requests without making real provider calls or needing live credentials. Wires AI settings through the SDK config path and adds a global `--dry-run-ai` flag.

## Why it matters (beyond dry-run)

Iteration 1, step 2 of the AI plan (ossf/pvtr-github-repo-scanner#273). It lays groundwork the later phases depend on:

- **Config → client seam.** `ConfigFromSDKConfig` + `--dry-run-ai` turn `ai_*` vars and CLI flags into a provider-neutral `Config`. Every Phase 2 per-step check reuses this path; dry-run is its first end-to-end consumer.
- **Opt-in / no-key invariant.** API key is required only for live calls, and `configured=false` separates "intentionally off" from "misconfigured" — the branches deterministic-first fallback relies on.
- **Zero-cost test harness.** A predictable `dry_run` finish reason plus logged prompt/model/token details let authors, CI, and reviewers validate prompts and `ai_max_tokens` bounds without spending tokens or credentials.

## Notes

Keeps the AI surface provider-neutral, validates structured schemas in dry-run the same as live providers, and reads AI settings from the CLI's runtime config (not just `config.Config.Vars`). Builds on the provider-neutral AI client + OpenAI adapter from #218.

Fixes #217.
