### PR TITLE
feat(ai): add AI evidence packet writer

### DIFF
--- a/ai/evidence.go
+++ b/ai/evidence.go
@@ -154,6 +154,11 @@ type AIInteractionEvidence struct {
 // configured values (APIKey, BaseURL credentials, sensitive config.Vars, and
 // any ExtraSecretValues supplied by the caller) plus pattern-based scrubbers
 // for bearer tokens and other common token-shaped values.
+//
+// When packet writing is enabled, WritePacket can return configuration errors
+// such as a wrong-typed ai_write_evidence value or invalid AI setting, packet
+// directory creation errors including collisions, file I/O errors, or an error
+// if redaction leaves a packet body as invalid JSON.
 func WritePacket(config sdkconfig.Config, attempt PacketAttempt) error {
 	if !config.Write {
 		return nil
@@ -197,7 +202,7 @@ func WritePacket(config sdkconfig.Config, attempt PacketAttempt) error {
 		controlID,
 		packetDirectoryName(sanitizer.RedactText(packetRequestID(attempt.Response))),
 	)
-	if err := os.MkdirAll(packetDir, 0o750); err != nil {
+	if err := createPacketDirectory(packetDir); err != nil {
 		return err
 	}
 
@@ -247,6 +252,13 @@ func WritePacket(config sdkconfig.Config, attempt PacketAttempt) error {
 		return err
 	}
 	return nil
+}
+
+func createPacketDirectory(packetDir string) error {
+	if err := os.MkdirAll(filepath.Dir(packetDir), 0o750); err != nil {
+		return err
+	}
+	return os.Mkdir(packetDir, 0o750)
 }
 
 func evidenceWritingEnabled(config sdkconfig.Config) (bool, error) {
@@ -364,14 +376,23 @@ type Sanitizer struct {
 	secretValues []string
 }
 
-// NewSanitizer assembles a Sanitizer for the given SDK config. It extracts
-// known sensitive values (AI API key, credentials embedded in ai_base_url,
-// and any config.Vars whose key looks sensitive) and combines them with
-// the supplied extraSecretValues. Callers can use the returned Sanitizer
-// directly to sanitize log output before WritePacket runs.
+// NewSanitizer assembles a best-effort Sanitizer for the given SDK config. It
+// preserves the original no-error API by ignoring AI config parsing errors;
+// callers that need to surface those errors should use NewSanitizerWithConfig.
 func NewSanitizer(config sdkconfig.Config, extraSecretValues ...string) Sanitizer {
-	aiConfig, _, _ := ConfigFromSDKConfig(config)
-	return newPacketSanitizer(config, aiConfig, extraSecretValues)
+	sanitizer, _ := NewSanitizerWithConfig(config, extraSecretValues...)
+	return sanitizer
+}
+
+// NewSanitizerWithConfig assembles a Sanitizer for the given SDK config and
+// returns AI config parsing errors instead of silently falling back to only the
+// sensitive values available in config.Vars and extraSecretValues.
+func NewSanitizerWithConfig(config sdkconfig.Config, extraSecretValues ...string) (Sanitizer, error) {
+	aiConfig, _, err := ConfigFromSDKConfig(config)
+	if err != nil {
+		return newPacketSanitizer(config, Config{}, extraSecretValues), err
+	}
+	return newPacketSanitizer(config, aiConfig, extraSecretValues), nil
 }
 
 func newPacketSanitizer(config sdkconfig.Config, aiConfig Config, extraSecretValues []string) Sanitizer {
@@ -417,8 +438,21 @@ func newPacketSanitizer(config sdkconfig.Config, aiConfig Config, extraSecretVal
 func (s Sanitizer) RedactText(value string) string {
 	for _, secretValue := range s.secretValues {
 		value = strings.ReplaceAll(value, secretValue, "REDACTED")
+		// Packet bytes may already be JSON-escaped when the final whole-file
+		// redaction pass runs, so scrub the representation that reaches disk too.
+		if escaped := jsonEscapedString(secretValue); escaped != secretValue {
+			value = strings.ReplaceAll(value, escaped, "REDACTED")
+		}
 	}
 	return RedactPatterns(value)
+}
+
+func jsonEscapedString(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil || len(encoded) < 2 {
+		return value
+	}
+	return string(encoded[1 : len(encoded)-1])
 }
 
 // RedactConfigValue returns the empty string for empty input and "REDACTED"
@@ -479,15 +513,11 @@ var packetPatternRedactors = []struct {
 	replacement string
 }{
 	{
-		pattern:     regexp.MustCompile(`(?i)(authorization\s*:\s*bearer\s+)([^\s"'` + "`" + `]+)`),
+		pattern:     regexp.MustCompile(`(?i)(authorization\s*[:=]\s*bearer\s+)([^\s"'` + "`" + `]+)`),
 		replacement: `${1}REDACTED`,
 	},
 	{
-		pattern:     regexp.MustCompile(`(?i)(\b(?:api[_-]?key|token|secret|password|auth)\b\s*[:=]\s*)([^\s"'` + "`" + `,;&\\]+)`),
-		replacement: `${1}REDACTED`,
-	},
-	{
-		pattern:     regexp.MustCompile(`(?i)("(?:api[_-]?key|token|secret|password|auth)"\s*:\s*")([^"]+)(")`),
+		pattern:     regexp.MustCompile(`(?i)("(?:api[_-]?key|token|secret|password|auth|authorization)"\s*:\s*")((?:\\.|[^"\\])+)(")`),
 		replacement: `${1}REDACTED${3}`,
 	},
 	{
@@ -505,10 +535,56 @@ var packetPatternRedactors = []struct {
 // places other than the packet itself (such as scanner logs) using the same
 // rules as WritePacket.
 func RedactPatterns(value string) string {
+	value = redactAssignmentSecrets(value)
 	for _, redactor := range packetPatternRedactors {
 		value = redactor.pattern.ReplaceAllString(value, redactor.replacement)
 	}
 	return value
+}
+
+var assignmentSecretPrefixPattern = regexp.MustCompile(`(?i)\b(?:api[_-]?key|token|secret|password|auth|authorization)\b\s*[:=]\s*`)
+
+func redactAssignmentSecrets(value string) string {
+	matches := assignmentSecretPrefixPattern.FindAllStringIndex(value, -1)
+	if len(matches) == 0 {
+		return value
+	}
+
+	var builder strings.Builder
+	lastIndex := 0
+	for _, match := range matches {
+		if match[0] < lastIndex {
+			continue
+		}
+
+		secretStart := match[1]
+		secretEnd := secretStart
+		for secretEnd < len(value) {
+			switch value[secretEnd] {
+			case ' ', '\t', '\n', '\r', '"', '\'', '`':
+				goto foundEnd
+			default:
+				secretEnd++
+			}
+		}
+
+	foundEnd:
+		if secretEnd == secretStart {
+			continue
+		}
+
+		secretText := value[secretStart:secretEnd]
+		prefixText := strings.ToLower(strings.TrimSpace(value[match[0]:secretStart]))
+		if strings.EqualFold(secretText, "Bearer") && strings.HasPrefix(prefixText, "authorization") {
+			continue
+		}
+
+		builder.WriteString(value[lastIndex:secretStart])
+		builder.WriteString("REDACTED")
+		lastIndex = secretEnd
+	}
+	builder.WriteString(value[lastIndex:])
+	return builder.String()
 }
 
 func urlSecretValues(rawURL string) []string {
@@ -542,13 +618,71 @@ func urlSecretValues(rawURL string) []string {
 }
 
 func isSensitivePacketKey(key string) bool {
-	lowerKey := strings.ToLower(strings.TrimSpace(key))
-	for _, pattern := range []string{"token", "auth", "password", "secret", "apikey", "api_key"} {
-		if strings.Contains(lowerKey, pattern) {
+	tokens := packetKeyTokens(key)
+	if len(tokens) == 0 {
+		return false
+	}
+
+	for _, token := range tokens {
+		switch token {
+		case "token", "password", "secret", "apikey", "authorization", "credential", "credentials":
+			return true
+		case "auth":
+			if len(tokens) == 1 {
+				return true
+			}
+		}
+	}
+
+	for index := 0; index+1 < len(tokens); index++ {
+		phrase := tokens[index] + "_" + tokens[index+1]
+		switch phrase {
+		case "api_key", "access_token", "auth_token", "client_secret", "bearer_token":
 			return true
 		}
 	}
 	return false
+}
+
+func packetKeyTokens(key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+
+	tokens := []string{}
+	for _, token := range strings.FieldsFunc(splitCamelCase(key), func(r rune) bool {
+		switch r {
+		case '_', '-', '.', '/', ':', ' ', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	}) {
+		if token != "" {
+			tokens = append(tokens, strings.ToLower(token))
+		}
+	}
+	return tokens
+}
+
+func splitCamelCase(value string) string {
+	var builder strings.Builder
+	runes := []rune(value)
+	for index, r := range runes {
+		if index > 0 && unicode.IsUpper(r) {
+			previous := runes[index-1]
+			nextIsLower := index+1 < len(runes) && unicode.IsLower(runes[index+1])
+			if unicode.IsLower(previous) || unicode.IsDigit(previous) || unicode.IsUpper(previous) && nextIsLower {
+				builder.WriteRune(' ')
+			}
+		}
+		if index > 0 && unicode.IsDigit(r) && unicode.IsLetter(runes[index-1]) {
+			builder.WriteRune(' ')
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
 }
 
 func packetSecretStrings(value interface{}) []string {
@@ -564,6 +698,16 @@ func packetSecretStrings(value interface{}) []string {
 			if strings.TrimSpace(item) != "" {
 				secretValues = append(secretValues, item)
 			}
+		}
+		return secretValues
+	case []interface{}:
+		secretValues := []string{}
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok || strings.TrimSpace(text) == "" {
+				continue
+			}
+			secretValues = append(secretValues, text)
 		}
 		return secretValues
 	case []byte:

--- a/ai/evidence.go
+++ b/ai/evidence.go
@@ -1,0 +1,600 @@
+package ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+)
+
+// DefaultPacketVersion is the schema version stamped into assessment.json
+// when PacketAttempt.PacketVersion is not set.
+const DefaultPacketVersion = "1"
+
+// PacketAttempt is the provider-neutral input for one AI evidence packet.
+// It carries everything WritePacket needs to persist a reviewable per-attempt
+// artifact set under <write-dir>/<service>/ai-evidence/<control-id>/. Fields
+// are intentionally generic so future AI-assisted controls (and future
+// providers) can reuse the same writer without modification.
+type PacketAttempt struct {
+	// ControlID is the OSPS control identifier (e.g. "OSPS-QA-06.02").
+	// Required: it becomes the parent directory under ai-evidence/.
+	ControlID string
+
+	// PacketVersion is the schema version stamped into assessment.json.
+	// Defaults to DefaultPacketVersion when empty.
+	PacketVersion string
+
+	// Repository context. Optional, included in assessment.json when set.
+	RepositoryOwner string
+	RepositoryName  string
+	DefaultBranch   string
+	CommitSHA       string
+
+	// Outcome is a free-form lifecycle label, typically "succeeded" or
+	// "failed". AttemptStage describes where in the attempt the writer was
+	// called from (e.g. "client_construction", "provider_call",
+	// "schema_validation", "assessment_completed").
+	Outcome      string
+	AttemptStage string
+
+	// Result, Confidence, and Verdict are the caller-domain summary fields
+	// rendered into assessment.json. They are strings so the SDK does not
+	// depend on any particular verdict type.
+	Result     string
+	Confidence string
+	Verdict    string
+
+	// Reasoning and EvidenceLocation come from the parsed structured AI
+	// response. The writer sanitizes them using configured values and
+	// token-shaped patterns before persistence.
+	Reasoning        string
+	EvidenceLocation string
+
+	// AssessmentMessage is the human-readable summary that the caller
+	// surfaces (e.g. in scanner logs). FailureMessage is derived from
+	// Failure when set.
+	AssessmentMessage string
+	Failure           error
+
+	// Provider interaction artifacts. The writer sanitizes prompt, evidence,
+	// and response content before persistence. Schema is copied for
+	// auditability, and the final JSON bytes pass through the same sanitizer
+	// as a defense-in-depth layer before disk write.
+	Prompt          string
+	Schema          *Schema
+	Evidence        string
+	EvidenceSources []string
+	Response        *AnalyzeResponse
+
+	// ExtraSecretValues lets callers register additional secret strings
+	// (e.g. GitHub tokens read from config.Vars) so the sanitizer can redact
+	// those exact values when they appear in packet text.
+	ExtraSecretValues []string
+}
+
+// AssessmentFile is the per-attempt summary written to assessment.json. It
+// captures the verdict mapping, attempt context, and redacted AI runtime
+// metadata in one human-readable file.
+type AssessmentFile struct {
+	PacketVersion     string                 `json:"packet_version"`
+	CapturedAt        string                 `json:"captured_at"`
+	ControlID         string                 `json:"control_id"`
+	ServiceName       string                 `json:"service_name"`
+	RepositoryOwner   string                 `json:"repository_owner,omitempty"`
+	RepositoryName    string                 `json:"repository_name,omitempty"`
+	DefaultBranch     string                 `json:"default_branch,omitempty"`
+	CommitSHA         string                 `json:"commit_sha,omitempty"`
+	Provider          Provider               `json:"provider"`
+	Model             string                 `json:"model"`
+	RequestID         string                 `json:"request_id,omitempty"`
+	FinishReason      string                 `json:"finish_reason,omitempty"`
+	Outcome           string                 `json:"outcome"`
+	AttemptStage      string                 `json:"attempt_stage,omitempty"`
+	Result            string                 `json:"result,omitempty"`
+	Confidence        string                 `json:"confidence,omitempty"`
+	AssessmentMessage string                 `json:"assessment_message,omitempty"`
+	FailureMessage    string                 `json:"failure_message,omitempty"`
+	Verdict           string                 `json:"verdict,omitempty"`
+	Reasoning         string                 `json:"reasoning,omitempty"`
+	EvidenceLocation  string                 `json:"evidence_location,omitempty"`
+	RedactedConfig    map[string]interface{} `json:"redacted_config"`
+}
+
+// AIInteractionFile is the per-attempt file written to ai_interaction.json. It
+// holds the prompt, the schema, the exact evidence body sent to the model,
+// the source locations the evidence was assembled from, and the raw
+// structured response, so a reviewer can reproduce or audit the verdict.
+type AIInteractionFile struct {
+	Prompt   string                `json:"prompt,omitempty"`
+	Schema   *AIInteractionSchema  `json:"schema,omitempty"`
+	Evidence AIInteractionEvidence `json:"evidence"`
+	Response json.RawMessage       `json:"response,omitempty"`
+}
+
+// AIInteractionSchema is the persisted view of the JSON Schema used for the
+// structured response. It is a plain serializable copy of ai.Schema.
+type AIInteractionSchema struct {
+	Name        string          `json:"name,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Strict      bool            `json:"strict"`
+	Value       json.RawMessage `json:"value,omitempty"`
+}
+
+// AIInteractionEvidence groups the evidence body and the source locations it
+// was assembled from. Sources are typically commit-pinned URLs.
+type AIInteractionEvidence struct {
+	Sources []string `json:"sources,omitempty"`
+	Content string   `json:"content,omitempty"`
+}
+
+// WritePacket persists a per-attempt AI evidence packet under
+// <write-dir>/<service>/ai-evidence/<control-id>/<timestamp>-<request-id>/
+// honoring the SDK config's Write flag and ai_write_evidence switch. It returns
+// nil (no-op) when writes are disabled, AI is not configured, AI evidence
+// writing is not explicitly enabled, WriteDirectory is empty, or ControlID is
+// empty.
+//
+// Two files are written per attempt:
+//   - assessment.json: verdict, attempt stage, outcome, repository context,
+//     and redacted AI runtime metadata.
+//   - ai_interaction.json: prompt, schema, evidence (sources + redacted body
+//     sent to the model), and the raw structured AI response.
+//
+// Before bytes are written to disk, packet content is sanitized using known
+// configured values (APIKey, BaseURL credentials, sensitive config.Vars, and
+// any ExtraSecretValues supplied by the caller) plus pattern-based scrubbers
+// for bearer tokens and other common token-shaped values.
+func WritePacket(config sdkconfig.Config, attempt PacketAttempt) error {
+	if !config.Write {
+		return nil
+	}
+	evidenceEnabled, err := evidenceWritingEnabled(config)
+	if err != nil {
+		return err
+	}
+	if !evidenceEnabled {
+		return nil
+	}
+	controlID := strings.TrimSpace(attempt.ControlID)
+	if controlID == "" {
+		return nil
+	}
+	writeDir := strings.TrimSpace(config.WriteDirectory)
+	if writeDir == "" {
+		return nil
+	}
+
+	serviceName := strings.TrimSpace(config.ServiceName)
+	if serviceName == "" {
+		serviceName = "overview"
+	}
+
+	aiConfig, configured, err := ConfigFromSDKConfig(config)
+	if err != nil {
+		return err
+	}
+	// Evidence packets contain the prompt, evidence body, and model response, so
+	// callers must opt in twice: configure AI assessment and enable packet writing.
+	if !configured {
+		return nil
+	}
+	sanitizer := newPacketSanitizer(config, aiConfig, attempt.ExtraSecretValues)
+
+	packetDir := filepath.Join(
+		writeDir,
+		serviceName,
+		"ai-evidence",
+		controlID,
+		packetDirectoryName(sanitizer.RedactText(packetRequestID(attempt.Response))),
+	)
+	if err := os.MkdirAll(packetDir, 0o750); err != nil {
+		return err
+	}
+
+	packetVersion := strings.TrimSpace(attempt.PacketVersion)
+	if packetVersion == "" {
+		packetVersion = DefaultPacketVersion
+	}
+
+	assessmentFile := AssessmentFile{
+		PacketVersion:     packetVersion,
+		CapturedAt:        time.Now().UTC().Format(time.RFC3339Nano),
+		ControlID:         controlID,
+		ServiceName:       serviceName,
+		RepositoryOwner:   strings.TrimSpace(attempt.RepositoryOwner),
+		RepositoryName:    strings.TrimSpace(attempt.RepositoryName),
+		DefaultBranch:     strings.TrimSpace(attempt.DefaultBranch),
+		CommitSHA:         strings.TrimSpace(attempt.CommitSHA),
+		Provider:          packetProvider(attempt.Response, aiConfig),
+		Model:             packetModel(attempt.Response, aiConfig),
+		RequestID:         packetRequestID(attempt.Response),
+		FinishReason:      packetFinishReason(attempt.Response),
+		Outcome:           strings.TrimSpace(attempt.Outcome),
+		AttemptStage:      strings.TrimSpace(attempt.AttemptStage),
+		Result:            strings.TrimSpace(attempt.Result),
+		Confidence:        strings.TrimSpace(attempt.Confidence),
+		AssessmentMessage: sanitizer.RedactText(attempt.AssessmentMessage),
+		FailureMessage:    sanitizer.RedactText(errorMessage(attempt.Failure)),
+		Verdict:           strings.TrimSpace(attempt.Verdict),
+		Reasoning:         sanitizer.RedactText(attempt.Reasoning),
+		EvidenceLocation:  sanitizer.RedactText(attempt.EvidenceLocation),
+		RedactedConfig: map[string]interface{}{
+			"provider":   aiConfig.Provider,
+			"model":      aiConfig.Model,
+			"base_url":   SanitizeURL(aiConfig.BaseURL),
+			"timeout":    aiConfig.Timeout.String(),
+			"max_tokens": aiConfig.MaxTokens,
+			"api_key":    RedactConfigValue(aiConfig.APIKey),
+		},
+	}
+
+	if err := writePacketJSON(filepath.Join(packetDir, "assessment.json"), assessmentFile, sanitizer); err != nil {
+		return err
+	}
+
+	interaction := buildAIInteraction(attempt, sanitizer)
+	if err := writePacketJSON(filepath.Join(packetDir, "ai_interaction.json"), interaction, sanitizer); err != nil {
+		return err
+	}
+	return nil
+}
+
+func evidenceWritingEnabled(config sdkconfig.Config) (bool, error) {
+	return getSDKConfigBool(config, "ai_write_evidence")
+}
+
+func buildAIInteraction(attempt PacketAttempt, sanitizer Sanitizer) AIInteractionFile {
+	file := AIInteractionFile{
+		Prompt: sanitizer.RedactText(attempt.Prompt),
+		Evidence: AIInteractionEvidence{
+			Sources: sanitizeEvidenceSources(attempt.EvidenceSources, sanitizer),
+			Content: sanitizer.RedactText(attempt.Evidence),
+		},
+	}
+	if attempt.Schema != nil {
+		file.Schema = &AIInteractionSchema{
+			Name:        attempt.Schema.Name,
+			Description: attempt.Schema.Description,
+			Strict:      attempt.Schema.Strict,
+			Value:       append(json.RawMessage(nil), attempt.Schema.Value...),
+		}
+	}
+	if attempt.Response != nil && len(attempt.Response.JSON) > 0 {
+		sanitized := sanitizer.RedactText(string(attempt.Response.JSON))
+		if json.Valid([]byte(sanitized)) {
+			file.Response = json.RawMessage(sanitized)
+		} else if encoded, err := json.Marshal(map[string]string{"raw_text": sanitized}); err == nil {
+			file.Response = encoded
+		}
+	}
+	return file
+}
+
+func sanitizeEvidenceSources(sources []string, sanitizer Sanitizer) []string {
+	if len(sources) == 0 {
+		return nil
+	}
+	sanitized := make([]string, 0, len(sources))
+	for _, source := range sources {
+		source = strings.TrimSpace(source)
+		if source == "" {
+			continue
+		}
+		sanitized = append(sanitized, sanitizer.RedactText(SanitizeURL(source)))
+	}
+	return sanitized
+}
+
+func packetDirectoryName(requestID string) string {
+	base := time.Now().UTC().Format("20060102T150405.000000000Z")
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return base + "-no-request-id"
+	}
+
+	var builder strings.Builder
+	for _, r := range requestID {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '-', r == '_', r == '.':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('_')
+		}
+	}
+	safe := strings.Trim(builder.String(), "._-")
+	if safe == "" {
+		safe = "request-id"
+	}
+	if len(safe) > 48 {
+		safe = safe[:48]
+	}
+	return base + "-" + safe
+}
+
+func packetProvider(response *AnalyzeResponse, config Config) Provider {
+	if response != nil && response.Metadata.Provider != "" {
+		return response.Metadata.Provider
+	}
+	return config.Provider
+}
+
+func packetModel(response *AnalyzeResponse, config Config) string {
+	if response != nil && strings.TrimSpace(response.Metadata.Model) != "" {
+		return response.Metadata.Model
+	}
+	return config.Model
+}
+
+func packetRequestID(response *AnalyzeResponse) string {
+	if response == nil {
+		return ""
+	}
+	return response.Metadata.RequestID
+}
+
+func packetFinishReason(response *AnalyzeResponse) string {
+	if response == nil {
+		return ""
+	}
+	return response.Metadata.FinishReason
+}
+
+func errorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// Sanitizer is a provider-neutral text scrubber for AI evidence packets.
+// It performs exact-value replacement for known sensitive values gathered
+// from config plus pattern-based redaction for common token-shaped strings
+// that may appear in evidence or model output.
+type Sanitizer struct {
+	secretValues []string
+}
+
+// NewSanitizer assembles a Sanitizer for the given SDK config. It extracts
+// known sensitive values (AI API key, credentials embedded in ai_base_url,
+// and any config.Vars whose key looks sensitive) and combines them with
+// the supplied extraSecretValues. Callers can use the returned Sanitizer
+// directly to sanitize log output before WritePacket runs.
+func NewSanitizer(config sdkconfig.Config, extraSecretValues ...string) Sanitizer {
+	aiConfig, _, _ := ConfigFromSDKConfig(config)
+	return newPacketSanitizer(config, aiConfig, extraSecretValues)
+}
+
+func newPacketSanitizer(config sdkconfig.Config, aiConfig Config, extraSecretValues []string) Sanitizer {
+	secretValues := []string{}
+	seen := map[string]struct{}{}
+	addSecretValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || value == "REDACTED" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		secretValues = append(secretValues, value)
+	}
+
+	addSecretValue(aiConfig.APIKey)
+	for _, value := range urlSecretValues(aiConfig.BaseURL) {
+		addSecretValue(value)
+	}
+	for key, value := range config.Vars {
+		if !isSensitivePacketKey(key) {
+			continue
+		}
+		for _, secretValue := range packetSecretStrings(value) {
+			addSecretValue(secretValue)
+		}
+	}
+	for _, value := range extraSecretValues {
+		addSecretValue(value)
+	}
+
+	sort.Slice(secretValues, func(i, j int) bool {
+		return len(secretValues[i]) > len(secretValues[j])
+	})
+
+	return Sanitizer{secretValues: secretValues}
+}
+
+// RedactText performs exact-value replacement followed by pattern-based
+// scrubbing and returns the sanitized string.
+func (s Sanitizer) RedactText(value string) string {
+	for _, secretValue := range s.secretValues {
+		value = strings.ReplaceAll(value, secretValue, "REDACTED")
+	}
+	return RedactPatterns(value)
+}
+
+// RedactConfigValue returns the empty string for empty input and "REDACTED"
+// for any other non-empty value. It is the standard renderer for known
+// secret config fields (such as ai_api_key) in packet metadata.
+func RedactConfigValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return "REDACTED"
+}
+
+// SanitizeURL preserves the structure of a URL while redacting embedded
+// credentials and the values of any sensitive query parameters. Unparseable
+// values are collapsed to "REDACTED".
+func SanitizeURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return RedactConfigValue(rawURL)
+	}
+
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword("REDACTED", "REDACTED")
+		} else {
+			parsed.User = url.User("REDACTED")
+		}
+	}
+
+	query := parsed.Query()
+	queryChanged := false
+	for key, values := range query {
+		if !isSensitivePacketKey(key) {
+			continue
+		}
+		queryChanged = true
+		for index := range values {
+			values[index] = "REDACTED"
+		}
+		query[key] = values
+	}
+	if queryChanged {
+		parsed.RawQuery = query.Encode()
+	}
+
+	return parsed.String()
+}
+
+// packetPatternRedactors is a defensive fallback for secrets that are not
+// present in config but still appear in evidence or model output.
+var packetPatternRedactors = []struct {
+	pattern     *regexp.Regexp
+	replacement string
+}{
+	{
+		pattern:     regexp.MustCompile(`(?i)(authorization\s*:\s*bearer\s+)([^\s"'` + "`" + `]+)`),
+		replacement: `${1}REDACTED`,
+	},
+	{
+		pattern:     regexp.MustCompile(`(?i)(\b(?:api[_-]?key|token|secret|password|auth)\b\s*[:=]\s*)([^\s"'` + "`" + `,;&\\]+)`),
+		replacement: `${1}REDACTED`,
+	},
+	{
+		pattern:     regexp.MustCompile(`(?i)("(?:api[_-]?key|token|secret|password|auth)"\s*:\s*")([^"]+)(")`),
+		replacement: `${1}REDACTED${3}`,
+	},
+	{
+		pattern:     regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{8,}\b`),
+		replacement: `REDACTED`,
+	},
+	{
+		pattern:     regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}\b`),
+		replacement: `REDACTED`,
+	},
+}
+
+// RedactPatterns applies the package's pattern-based token scrubbers to the
+// supplied string. It is exposed so callers can redact text destined for
+// places other than the packet itself (such as scanner logs) using the same
+// rules as WritePacket.
+func RedactPatterns(value string) string {
+	for _, redactor := range packetPatternRedactors {
+		value = redactor.pattern.ReplaceAllString(value, redactor.replacement)
+	}
+	return value
+}
+
+func urlSecretValues(rawURL string) []string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil
+	}
+
+	secretValues := []string{}
+	if parsed.User != nil {
+		if username := strings.TrimSpace(parsed.User.Username()); username != "" {
+			secretValues = append(secretValues, username)
+		}
+		if password, hasPassword := parsed.User.Password(); hasPassword && strings.TrimSpace(password) != "" {
+			secretValues = append(secretValues, password)
+		}
+	}
+	for key, values := range parsed.Query() {
+		if !isSensitivePacketKey(key) {
+			continue
+		}
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				secretValues = append(secretValues, value)
+			}
+		}
+	}
+
+	return secretValues
+}
+
+func isSensitivePacketKey(key string) bool {
+	lowerKey := strings.ToLower(strings.TrimSpace(key))
+	for _, pattern := range []string{"token", "auth", "password", "secret", "apikey", "api_key"} {
+		if strings.Contains(lowerKey, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func packetSecretStrings(value interface{}) []string {
+	switch typed := value.(type) {
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return nil
+		}
+		return []string{typed}
+	case []string:
+		secretValues := []string{}
+		for _, item := range typed {
+			if strings.TrimSpace(item) != "" {
+				secretValues = append(secretValues, item)
+			}
+		}
+		return secretValues
+	case []byte:
+		if strings.TrimSpace(string(typed)) == "" {
+			return nil
+		}
+		return []string{string(typed)}
+	default:
+		return nil
+	}
+}
+
+func writePacketJSON(path string, value interface{}, sanitizer Sanitizer) error {
+	var body []byte
+	var err error
+	if rawJSON, ok := value.(json.RawMessage); ok {
+		var formatted bytes.Buffer
+		if err = json.Indent(&formatted, rawJSON, "", "  "); err != nil {
+			return fmt.Errorf("indent json for %s: %w", path, err)
+		}
+		body = formatted.Bytes()
+	} else {
+		body, err = json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal json for %s: %w", path, err)
+		}
+	}
+	body = []byte(sanitizer.RedactText(string(body)))
+	if !json.Valid(body) {
+		return fmt.Errorf("redacted json for %s is invalid", path)
+	}
+	body = append(body, '\n')
+	return os.WriteFile(path, body, 0o640)
+}

--- a/ai/evidence_test.go
+++ b/ai/evidence_test.go
@@ -1,0 +1,421 @@
+package ai
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sdkconfig "github.com/privateerproj/privateer-sdk/config"
+)
+
+func newTestSDKConfig(t *testing.T, writeDir string) sdkconfig.Config {
+	t.Helper()
+	return sdkconfig.Config{
+		ServiceName:    "my-scan",
+		WriteDirectory: writeDir,
+		Write:          true,
+		Vars: map[string]interface{}{
+			"owner":             "test-owner",
+			"repo":              "test-repo",
+			"token":             "ghp_var_secret_123456",
+			"ai_provider":       "openai",
+			"ai_model":          "gpt-test",
+			"ai_api_key":        "super-secret-key",
+			"ai_base_url":       "https://proxy-user:proxy-pass@example.test/v1?api_key=query-secret&mode=test",
+			"ai_max_tokens":     256,
+			"ai_write_evidence": true,
+		},
+	}
+}
+
+func TestWritePacketSucceededAttempt(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+
+	attempt := PacketAttempt{
+		ControlID:         "OSPS-QA-06.02",
+		Outcome:           "succeeded",
+		AttemptStage:      "assessment_completed",
+		RepositoryOwner:   "test-owner",
+		RepositoryName:    "test-repo",
+		DefaultBranch:     "main",
+		CommitSHA:         "abc123def456",
+		Result:            "Passed",
+		Confidence:        "High",
+		Verdict:           "pass",
+		Reasoning:         "README explains contributors should run go test before opening a PR. Authorization: Bearer sk-live-1234567890abcdef",
+		EvidenceLocation:  "README#testing ghp_var_secret_123456",
+		AssessmentMessage: "[AI-Assisted] verdict=pass confidence=0.91",
+		Prompt:            "You are assessing test execution documentation with super-secret-key.",
+		Schema: &Schema{
+			Name:        "test_execution_documentation_assessment",
+			Description: "Structured assessment.",
+			Strict:      true,
+			Value:       json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"}},"required":["verdict"]}`),
+		},
+		Evidence: "README\nRun `go test ./...` before opening a PR. token: super-secret-key",
+		EvidenceSources: []string{
+			"https://github.com/test-owner/test-repo/blob/abc123def456/README.md",
+			"https://example.test/source?token=ghp_var_secret_123456&mode=test",
+		},
+		Response: &AnalyzeResponse{
+			Text: "raw model response",
+			JSON: []byte(`{"verdict":"pass","confidence":0.91,"reasoning":"README explains workflow. Authorization: Bearer sk-live-1234567890abcdef","evidence_location":"README#testing ghp_var_secret_123456"}`),
+			Metadata: ResponseMetadata{
+				Provider:     ProviderOpenAI,
+				Model:        "gpt-test-2024",
+				RequestID:    "req-XYZ_789",
+				FinishReason: "stop",
+			},
+		},
+		ExtraSecretValues: []string{"ghp_var_secret_123456"},
+	}
+
+	if err := WritePacket(config, attempt); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 packet directory, got %d (%v)", len(matches), matches)
+	}
+	packetDir := matches[0]
+
+	for _, name := range []string{"assessment.json", "ai_interaction.json"} {
+		if _, err := os.Stat(filepath.Join(packetDir, name)); err != nil {
+			t.Fatalf("expected packet file %s: %v", name, err)
+		}
+	}
+
+	assessmentBytes, err := os.ReadFile(filepath.Join(packetDir, "assessment.json"))
+	if err != nil {
+		t.Fatalf("read assessment: %v", err)
+	}
+	assessmentText := string(assessmentBytes)
+	for _, want := range []string{
+		`"packet_version": "1"`,
+		`"control_id": "OSPS-QA-06.02"`,
+		`"service_name": "my-scan"`,
+		`"repository_owner": "test-owner"`,
+		`"commit_sha": "abc123def456"`,
+		`"provider": "openai"`,
+		`"model": "gpt-test-2024"`,
+		`"request_id": "req-XYZ_789"`,
+		`"outcome": "succeeded"`,
+		`"attempt_stage": "assessment_completed"`,
+		`"result": "Passed"`,
+		`"verdict": "pass"`,
+		`"api_key": "REDACTED"`,
+		`"base_url": "https://REDACTED:REDACTED@example.test/v1?api_key=REDACTED\u0026mode=test"`,
+	} {
+		if !strings.Contains(assessmentText, want) {
+			t.Fatalf("assessment.json missing %s; got %s", want, assessmentText)
+		}
+	}
+
+	interactionBytes, err := os.ReadFile(filepath.Join(packetDir, "ai_interaction.json"))
+	if err != nil {
+		t.Fatalf("read ai_interaction: %v", err)
+	}
+	interactionText := string(interactionBytes)
+	for _, want := range []string{
+		`"prompt": "You are assessing test execution documentation with REDACTED."`,
+		`"schema":`,
+		`"name": "test_execution_documentation_assessment"`,
+		`"strict": true`,
+		`"evidence":`,
+		`"sources":`,
+		`"https://github.com/test-owner/test-repo/blob/abc123def456/README.md"`,
+		`"https://example.test/source?mode=test\u0026token=REDACTED"`,
+		`"content":`,
+		`"response":`,
+		`"verdict": "pass"`,
+	} {
+		if !strings.Contains(interactionText, want) {
+			t.Fatalf("ai_interaction.json missing %s; got %s", want, interactionText)
+		}
+	}
+
+	if err := filepath.WalkDir(packetDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(body)
+		for _, secret := range []string{
+			"super-secret-key",
+			"proxy-user",
+			"proxy-pass",
+			"query-secret",
+			"ghp_var_secret_123456",
+			"sk-live-1234567890abcdef",
+		} {
+			if strings.Contains(text, secret) {
+				t.Fatalf("packet file %s leaked secret %q", path, secret)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}
+
+func TestWritePacketFailedAttempt(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+
+	attempt := PacketAttempt{
+		ControlID:         "OSPS-QA-06.02",
+		Outcome:           "failed",
+		AttemptStage:      "provider_call",
+		AssessmentMessage: "Review project documentation to ensure it explains when and how tests are run",
+		Failure:           errors.New("provider unavailable"),
+		Prompt:            "prompt",
+		Evidence:          "README\nbody",
+		EvidenceSources:   []string{"https://github.com/test-owner/test-repo/blob/abc123def456/README.md"},
+	}
+
+	if err := WritePacket(config, attempt); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 packet directory, got %d", len(matches))
+	}
+	body, err := os.ReadFile(filepath.Join(matches[0], "assessment.json"))
+	if err != nil {
+		t.Fatalf("read assessment: %v", err)
+	}
+	for _, want := range []string{
+		`"provider": "openai"`,
+		`"model": "gpt-test"`,
+		`"outcome": "failed"`,
+		`"attempt_stage": "provider_call"`,
+		`"failure_message": "provider unavailable"`,
+		`"assessment_message": "Review project documentation to ensure it explains when and how tests are run"`,
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("assessment.json missing %s; got %s", want, string(body))
+		}
+	}
+}
+
+func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+
+	attempt := PacketAttempt{
+		ControlID:       "OSPS-QA-06.02",
+		Outcome:         "succeeded",
+		AttemptStage:    "assessment_completed",
+		RepositoryOwner: "test-owner",
+		RepositoryName:  "test-repo",
+		DefaultBranch:   "super-secret-key",
+		Verdict:         "ghp_verdict_secret_123456",
+		Schema: &Schema{
+			Name:        "schema_name",
+			Description: "schema description with super-secret-key",
+			Strict:      true,
+			Value:       json.RawMessage(`{"type":"object","properties":{"token":{"type":"string"}},"required":["token"]}`),
+		},
+		Response: &AnalyzeResponse{
+			JSON: []byte(`{"token":"ghp_response_secret_123456","reasoning":"ok"}`),
+			Metadata: ResponseMetadata{
+				Provider:  ProviderOpenAI,
+				Model:     "gpt-test",
+				RequestID: "ghp_request_secret_123456",
+			},
+		},
+	}
+
+	if err := WritePacket(config, attempt); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 packet directory, got %d (%v)", len(matches), matches)
+	}
+	if strings.Contains(filepath.Base(matches[0]), "ghp_request_secret_123456") {
+		t.Fatalf("packet directory leaked request id secret: %s", matches[0])
+	}
+
+	if err := filepath.WalkDir(matches[0], func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, secret := range []string{
+			"super-secret-key",
+			"ghp_verdict_secret_123456",
+			"ghp_response_secret_123456",
+			"ghp_request_secret_123456",
+		} {
+			if strings.Contains(string(body), secret) {
+				t.Fatalf("packet file %s leaked secret %q", path, secret)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}
+
+func TestWritePacketNoopWhenWriteDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+	config.Write = false
+
+	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
+		t.Fatalf("expected no packet output, found %d entries", len(entries))
+	}
+}
+
+func TestWritePacketNoopWhenEvidenceWritingDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+	config.Vars["ai_write_evidence"] = false
+
+	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
+		t.Fatalf("expected no packet output when ai_write_evidence is false, found %d entries", len(entries))
+	}
+}
+
+func TestWritePacketRejectsWrongTypedEvidenceWritingConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+	config.Vars["ai_write_evidence"] = "true"
+
+	err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"})
+	if err == nil {
+		t.Fatal("expected wrong-typed ai_write_evidence error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ai_write_evidence must be a bool") {
+		t.Fatalf("error = %q, want ai_write_evidence type error", err.Error())
+	}
+	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
+		t.Fatalf("expected no packet output when ai_write_evidence is wrong-typed, found %d entries", len(entries))
+	}
+}
+
+func TestWritePacketNoopWhenAIUnconfigured(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+	config.Vars = map[string]interface{}{
+		"ai_write_evidence": true,
+	}
+
+	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
+		t.Fatalf("expected no packet output when AI is unconfigured, found %d entries", len(entries))
+	}
+}
+
+func TestWritePacketNoopWhenControlIDMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	config := newTestSDKConfig(t, tempDir)
+
+	if err := WritePacket(config, PacketAttempt{}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
+		t.Fatalf("expected no packet output when ControlID is empty, found %d", len(entries))
+	}
+}
+
+func TestSanitizerRedactsConfiguredAndPatternSecrets(t *testing.T) {
+	config := newTestSDKConfig(t, t.TempDir())
+	sanitizer := NewSanitizer(config, "extra-secret-token")
+
+	got := sanitizer.RedactText("super-secret-key extra-secret-token Authorization: Bearer sk-abcdefg12345 ghp_abcdefg12345")
+	for _, leaked := range []string{"super-secret-key", "extra-secret-token", "sk-abcdefg12345", "ghp_abcdefg12345"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("Sanitizer leaked %q in %q", leaked, got)
+		}
+	}
+}
+
+func TestSanitizeURLRedactsCredentialsAndQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "credentials and query", input: "https://proxy-user:proxy-pass@example.test/v1?api_key=secret&mode=test", want: "https://REDACTED:REDACTED@example.test/v1?api_key=REDACTED&mode=test"},
+		{name: "invalid", input: "://bad url", want: "REDACTED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeURL(tt.input); got != tt.want {
+				t.Fatalf("SanitizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactPatterns(t *testing.T) {
+	input := strings.Join([]string{
+		"Authorization: Bearer sk-live-1234567890abcdef",
+		"api_key=plain-secret",
+		"token: ghp_secret_12345678",
+		`{"token":"ghp_json_secret_12345678","api_key":"plain-json-secret"}`,
+	}, "\n")
+	got := RedactPatterns(input)
+	for _, leaked := range []string{"sk-live-1234567890abcdef", "plain-secret", "ghp_secret_12345678", "ghp_json_secret_12345678", "plain-json-secret"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("RedactPatterns leaked %q in %q", leaked, got)
+		}
+	}
+	for _, want := range []string{"Authorization: Bearer REDACTED", "api_key=REDACTED", "token: REDACTED", `"token":"REDACTED"`, `"api_key":"REDACTED"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RedactPatterns missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestRedactConfigValue(t *testing.T) {
+	if got := RedactConfigValue(""); got != "" {
+		t.Fatalf("empty input: got %q", got)
+	}
+	if got := RedactConfigValue("  "); got != "" {
+		t.Fatalf("whitespace input: got %q", got)
+	}
+	if got := RedactConfigValue("anything"); got != "REDACTED" {
+		t.Fatalf("non-empty input: got %q", got)
+	}
+}

--- a/ai/evidence_test.go
+++ b/ai/evidence_test.go
@@ -35,7 +35,6 @@ func newTestSDKConfig(t *testing.T, writeDir string) sdkconfig.Config {
 func TestWritePacketSucceededAttempt(t *testing.T) {
 	tempDir := t.TempDir()
 	config := newTestSDKConfig(t, tempDir)
-
 	attempt := PacketAttempt{
 		ControlID:         "OSPS-QA-06.02",
 		Outcome:           "succeeded",
@@ -113,7 +112,7 @@ func TestWritePacketSucceededAttempt(t *testing.T) {
 		`"result": "Passed"`,
 		`"verdict": "pass"`,
 		`"api_key": "REDACTED"`,
-		`"base_url": "https://REDACTED:REDACTED@example.test/v1?api_key=REDACTED\u0026mode=test"`,
+		`"base_url": "https://REDACTED:REDACTED@example.test/v1?api_key=REDACTED"`,
 	} {
 		if !strings.Contains(assessmentText, want) {
 			t.Fatalf("assessment.json missing %s; got %s", want, assessmentText)
@@ -220,6 +219,8 @@ func TestWritePacketFailedAttempt(t *testing.T) {
 func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testing.T) {
 	tempDir := t.TempDir()
 	config := newTestSDKConfig(t, tempDir)
+	escapedSecret := `pa&ss"word\tail<end>`
+	config.Vars["token"] = escapedSecret
 
 	attempt := PacketAttempt{
 		ControlID:       "OSPS-QA-06.02",
@@ -228,10 +229,10 @@ func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testin
 		RepositoryOwner: "test-owner",
 		RepositoryName:  "test-repo",
 		DefaultBranch:   "super-secret-key",
-		Verdict:         "ghp_verdict_secret_123456",
+		Verdict:         escapedSecret,
 		Schema: &Schema{
 			Name:        "schema_name",
-			Description: "schema description with super-secret-key",
+			Description: "schema description with super-secret-key and " + escapedSecret,
 			Strict:      true,
 			Value:       json.RawMessage(`{"type":"object","properties":{"token":{"type":"string"}},"required":["token"]}`),
 		},
@@ -273,7 +274,8 @@ func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testin
 		}
 		for _, secret := range []string{
 			"super-secret-key",
-			"ghp_verdict_secret_123456",
+			escapedSecret,
+			jsonEscapedString(escapedSecret),
 			"ghp_response_secret_123456",
 			"ghp_request_secret_123456",
 		} {
@@ -357,14 +359,81 @@ func TestWritePacketNoopWhenControlIDMissing(t *testing.T) {
 	}
 }
 
+func TestCreatePacketDirectoryFailsWhenPacketDirectoryExists(t *testing.T) {
+	packetDir := filepath.Join(t.TempDir(), "my-scan", "ai-evidence", "OSPS-QA-06.02", "packet")
+	if err := createPacketDirectory(packetDir); err != nil {
+		t.Fatalf("createPacketDirectory first call: %v", err)
+	}
+	if err := createPacketDirectory(packetDir); err == nil {
+		t.Fatal("createPacketDirectory second call succeeded, want collision error")
+	}
+}
+
 func TestSanitizerRedactsConfiguredAndPatternSecrets(t *testing.T) {
 	config := newTestSDKConfig(t, t.TempDir())
+	config.Vars["token_list"] = []interface{}{"list-secret-token", 123, ""}
 	sanitizer := NewSanitizer(config, "extra-secret-token")
 
-	got := sanitizer.RedactText("super-secret-key extra-secret-token Authorization: Bearer sk-abcdefg12345 ghp_abcdefg12345")
-	for _, leaked := range []string{"super-secret-key", "extra-secret-token", "sk-abcdefg12345", "ghp_abcdefg12345"} {
+	got := sanitizer.RedactText("super-secret-key extra-secret-token list-secret-token Authorization: Bearer sk-abcdefg12345 ghp_abcdefg12345")
+	for _, leaked := range []string{"super-secret-key", "extra-secret-token", "list-secret-token", "sk-abcdefg12345", "ghp_abcdefg12345"} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("Sanitizer leaked %q in %q", leaked, got)
+		}
+	}
+}
+
+func TestNewSanitizerWithConfigReturnsAIConfigErrors(t *testing.T) {
+	config := newTestSDKConfig(t, t.TempDir())
+	config.Vars["ai_timeout"] = "bad-timeout"
+
+	sanitizer, err := NewSanitizerWithConfig(config, "extra-secret-token")
+	if err == nil {
+		t.Fatal("expected invalid AI config error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid ai_timeout") {
+		t.Fatalf("error = %q, want invalid ai_timeout", err.Error())
+	}
+
+	got := sanitizer.RedactText("super-secret-key extra-secret-token")
+	for _, leaked := range []string{"super-secret-key", "extra-secret-token"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("Sanitizer leaked %q in %q", leaked, got)
+		}
+	}
+}
+
+func TestNewSanitizerRemainsBestEffortWhenAIConfigIsInvalid(t *testing.T) {
+	config := newTestSDKConfig(t, t.TempDir())
+	config.Vars["ai_timeout"] = "bad-timeout"
+
+	sanitizer := NewSanitizer(config, "extra-secret-token")
+	got := sanitizer.RedactText("super-secret-key extra-secret-token")
+	for _, leaked := range []string{"super-secret-key", "extra-secret-token"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("Sanitizer leaked %q in %q", leaked, got)
+		}
+	}
+}
+
+func TestSanitizerDoesNotTreatAuthorAsSensitiveKey(t *testing.T) {
+	config := newTestSDKConfig(t, t.TempDir())
+	config.Vars["author"] = "Jane Doe"
+	config.Vars["auth_token"] = "real-secret-token"
+	config.Vars["authorization"] = "Bearer authorization-secret"
+	config.Vars["client-secret"] = "client-secret-value"
+	config.Vars["service.api-key"] = "api-key-value"
+	config.Vars["accessToken"] = "access-token-value"
+	config.Vars["clientSecret"] = "client-secret-camel-value"
+	config.Vars["APIKey"] = "api-key-initialism-value"
+	sanitizer := NewSanitizer(config)
+
+	got := sanitizer.RedactText("Jane Doe real-secret-token Bearer authorization-secret client-secret-value api-key-value access-token-value client-secret-camel-value api-key-initialism-value")
+	if !strings.Contains(got, "Jane Doe") {
+		t.Fatalf("Sanitizer unexpectedly redacted author value: %q", got)
+	}
+	for _, leaked := range []string{"real-secret-token", "Bearer authorization-secret", "client-secret-value", "api-key-value", "access-token-value", "client-secret-camel-value", "api-key-initialism-value"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("Sanitizer leaked sensitive key value %q in %q", leaked, got)
 		}
 	}
 }
@@ -377,6 +446,7 @@ func TestSanitizeURLRedactsCredentialsAndQuery(t *testing.T) {
 	}{
 		{name: "empty", input: "", want: ""},
 		{name: "credentials and query", input: "https://proxy-user:proxy-pass@example.test/v1?api_key=secret&mode=test", want: "https://REDACTED:REDACTED@example.test/v1?api_key=REDACTED&mode=test"},
+		{name: "authorization query preserves author", input: "https://example.test/v1?authorization=bearer-secret&author=Jane&mode=test", want: "https://example.test/v1?author=Jane&authorization=REDACTED&mode=test"},
 		{name: "invalid", input: "://bad url", want: "REDACTED"},
 	}
 	for _, tt := range tests {
@@ -392,19 +462,37 @@ func TestRedactPatterns(t *testing.T) {
 	input := strings.Join([]string{
 		"Authorization: Bearer sk-live-1234567890abcdef",
 		"api_key=plain-secret",
+		"authorization=bearer-secret",
+		"authorization=Bearer bearer-assignment-secret",
+		"password=abc,def;ghi&jkl\\tail",
+		"secret=abc&next=still-secret",
+		`token=abc\u0026mode=still-secret`,
+		`api_key=REDACTED\u0026mode=test`,
+		"password=REDACTED&still-secret",
+		"password=REDACTED&still=secret",
+		"password=REDACTED-real-secret",
+		"password=Bearer",
 		"token: ghp_secret_12345678",
-		`{"token":"ghp_json_secret_12345678","api_key":"plain-json-secret"}`,
+		`{"token":"ghp_json_secret_12345678","api_key":"plain-json-secret","authorization":"json-authorization-secret","password":"quoted\"secret-value"}`,
 	}, "\n")
 	got := RedactPatterns(input)
-	for _, leaked := range []string{"sk-live-1234567890abcdef", "plain-secret", "ghp_secret_12345678", "ghp_json_secret_12345678", "plain-json-secret"} {
+	for _, leaked := range []string{"sk-live-1234567890abcdef", "plain-secret", "bearer-secret", "bearer-assignment-secret", "abc,def;ghi&jkl\\tail", "abc&next=still-secret", `abc\u0026mode=still-secret`, "REDACTED&still-secret", "REDACTED&still=secret", "REDACTED-real-secret", "ghp_secret_12345678", "ghp_json_secret_12345678", "plain-json-secret", "json-authorization-secret", `quoted\"secret-value`} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("RedactPatterns leaked %q in %q", leaked, got)
 		}
 	}
-	for _, want := range []string{"Authorization: Bearer REDACTED", "api_key=REDACTED", "token: REDACTED", `"token":"REDACTED"`, `"api_key":"REDACTED"`} {
+	for _, want := range []string{"Authorization: Bearer REDACTED", "api_key=REDACTED", "authorization=REDACTED", "authorization=Bearer REDACTED", "password=REDACTED", "secret=REDACTED", `token=REDACTED`, "token: REDACTED", `"token":"REDACTED"`, `"api_key":"REDACTED"`, `"authorization":"REDACTED"`, `"password":"REDACTED"`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("RedactPatterns missing %q in %q", want, got)
 		}
+	}
+	inputJSON := strings.Split(input, "\n")[13]
+	gotJSON := strings.Split(got, "\n")[13]
+	if !json.Valid([]byte(inputJSON)) {
+		t.Fatal("test fixture must remain valid JSON")
+	}
+	if !json.Valid([]byte(gotJSON)) {
+		t.Fatalf("RedactPatterns produced invalid JSON object: %q", gotJSON)
 	}
 }
 

--- a/command/base.go
+++ b/command/base.go
@@ -49,6 +49,9 @@ func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("dry-run-ai", false, "Log AI prompts and model settings without making real provider requests")
 	_ = viper.BindPFlag("ai_dry_run", cmd.PersistentFlags().Lookup("dry-run-ai"))
 
+	cmd.PersistentFlags().Bool("write-ai-evidence", false, "Write AI evidence packets when AI assessment is configured")
+	_ = viper.BindPFlag("ai_write_evidence", cmd.PersistentFlags().Lookup("write-ai-evidence"))
+
 	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }
 

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -61,6 +61,27 @@ func TestSetBase_DryRunAIFlag(t *testing.T) {
 	}
 }
 
+func TestSetBase_WriteAIEvidenceFlag(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "test"}
+	SetBase(cmd)
+
+	flag := cmd.PersistentFlags().Lookup("write-ai-evidence")
+	if flag == nil {
+		t.Fatal("expected write-ai-evidence flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("expected write-ai-evidence default to be 'false', got %q", flag.DefValue)
+	}
+	if err := cmd.PersistentFlags().Set("write-ai-evidence", "true"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+	// The flag is bound to ai_write_evidence so config, env, and CLI use one key.
+	if !viper.GetBool("ai_write_evidence") {
+		t.Error("expected viper ai_write_evidence=true after --write-ai-evidence flag set")
+	}
+}
+
 func TestReadConfig_ExplicitConfigPath(t *testing.T) {
 	resetViper()
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ var inheritedTopLevelVarKeys = []string{
 	"ai_timeout",
 	"ai_max_tokens",
 	"ai_dry_run",
+	"ai_write_evidence",
 }
 
 // Config holds the configuration for a plugin execution.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -517,6 +517,7 @@ ai_base_url: http://127.0.0.1:8000/v1
 ai_timeout: 45s
 ai_max_tokens: 1024
 ai_dry_run: true
+ai_write_evidence: true
 services:
   my-service-1:
     policy:
@@ -532,13 +533,14 @@ services:
 	c := NewConfig(nil)
 
 	for key, want := range map[string]interface{}{
-		"ai_provider":   "openai",
-		"ai_model":      "gpt-5.4-mini",
-		"ai_api_key":    "top-level-key",
-		"ai_base_url":   "http://127.0.0.1:8000/v1",
-		"ai_timeout":    "45s",
-		"ai_max_tokens": 1024,
-		"ai_dry_run":    true,
+		"ai_provider":       "openai",
+		"ai_model":          "gpt-5.4-mini",
+		"ai_api_key":        "top-level-key",
+		"ai_base_url":       "http://127.0.0.1:8000/v1",
+		"ai_timeout":        "45s",
+		"ai_max_tokens":     1024,
+		"ai_dry_run":        true,
+		"ai_write_evidence": true,
 	} {
 		if got, ok := c.Vars[key]; !ok || got != want {
 			t.Fatalf("Vars[%q] = %#v, want %#v", key, got, want)
@@ -550,8 +552,12 @@ func TestNewConfig_DoesNotInheritBoundFlagDefaultIntoVars(t *testing.T) {
 	viper.Reset()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.Bool("dry-run-ai", false, "")
+	flags.Bool("write-ai-evidence", false, "")
 	if err := viper.BindPFlag("ai_dry_run", flags.Lookup("dry-run-ai")); err != nil {
 		t.Fatalf("failed to bind dry-run flag: %v", err)
+	}
+	if err := viper.BindPFlag("ai_write_evidence", flags.Lookup("write-ai-evidence")); err != nil {
+		t.Fatalf("failed to bind write AI evidence flag: %v", err)
 	}
 	viper.Set("service", "my-service-1")
 	viper.Set("services.my-service-1.policy.catalogs", []string{"FINOS-CCC"})
@@ -559,6 +565,9 @@ func TestNewConfig_DoesNotInheritBoundFlagDefaultIntoVars(t *testing.T) {
 
 	c := NewConfig(nil)
 	if got, ok := c.Vars["ai_dry_run"]; ok {
+		t.Fatalf("did not expect bound flag default to be inherited into Vars, got %#v", got)
+	}
+	if got, ok := c.Vars["ai_write_evidence"]; ok {
 		t.Fatalf("did not expect bound flag default to be inherited into Vars, got %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a provider-neutral AI evidence packet writer for AI-assisted controls. Each enabled attempt writes a reviewable packet containing assessment metadata and the AI interaction artifacts needed for later audit.

Fixes privateerproj/privateer-sdk#230
Related to ossf/pvtr-github-repo-scanner#273

## Provider neutrality

This lives in the SDK so evidence capture stays provider-neutral: callers pass the shared AI schema and response types, while provider-specific auth, request bodies, endpoints, and response parsing remain inside provider adapters.

## What changed

- Add ai.WritePacket and provider-neutral packet types for assessment.json and ai_interaction.json
- Persist prompt, schema, evidence content, evidence sources, structured response, mapped verdict, provider, model, and request metadata
- Add layered redaction for configured secrets, URL credentials, sensitive query parameters, token-shaped values, and a final whole-file redaction pass before writing JSON
- Add ai_write_evidence config support and --write-ai-evidence CLI support
- Add focused tests for success, failure, no-op gating, redaction, URL sanitization, config inheritance, CLI binding, and wrong-typed config values

## Optional evidence writing

Evidence packet writing is intentionally a separate opt-in from enabling AI. A run must have AI configured and must also set ai_write_evidence: true or pass --write-ai-evidence before packets are written. This lets operators use AI assessment without automatically persisting prompt, evidence, and response artifacts, which is especially useful in CI where artifacts may be retained or shared more broadly.

The existing global write flag still acts as an outer guard. If normal result writing is disabled, AI evidence packets are not written either.
