### PR TITLE
refactor(command): extract planRun to unit-test Run's selection logic

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -38,6 +38,34 @@ func mergeExitCode(prev, next int) int {
 	return prev
 }
 
+// planRun decides, without executing anything, what Run should do with the
+// resolved plugin list:
+//   - toRun is the requested-and-installed plugins to execute, in input order.
+//   - earlyExit is non-zero when Run must return immediately without executing:
+//     NoTests when the plugin list is empty, BadUsage when a requested plugin
+//     is not installed (culprit names it, for the log line).
+//
+// Pulling this decision out of the execution loop lets it be table-tested
+// without go-plugin fakes. It validates the whole list up front, so a config
+// that requests an uninstalled plugin now fails before any plugin runs.
+// Previously a requested+installed plugin earlier in the (map-ordered, so
+// non-deterministic) slice could execute before the BadUsage abort.
+func planRun(plugins []*PluginPkg) (toRun []*PluginPkg, earlyExit int, culprit *PluginPkg) {
+	if len(plugins) == 0 {
+		return nil, NoTests, nil
+	}
+	for _, pluginPkg := range plugins {
+		if !pluginPkg.Requested {
+			continue
+		}
+		if !pluginPkg.Installed {
+			return nil, BadUsage, pluginPkg
+		}
+		toRun = append(toRun, pluginPkg)
+	}
+	return toRun, 0, nil
+}
+
 // Run executes all plugins with handling for the command line.
 //
 // Deprecated: use harness.Run instead. This will be removed once the pvtr CLI
@@ -46,22 +74,19 @@ func Run(logger hclog.Logger, getPlugins func() []*PluginPkg) (exitCode int) {
 	logger.Trace(fmt.Sprintf(
 		"Using bin: %s", viper.GetString("binaries-path")))
 
-	plugins := getPlugins()
-	if len(plugins) == 0 {
+	toRun, earlyExit, culprit := planRun(getPlugins())
+	switch earlyExit {
+	case NoTests:
 		logger.Error(fmt.Sprintf("no plugins were requested in config: %s", viper.GetString("binaries-path")))
 		return NoTests
+	case BadUsage:
+		logger.Error(fmt.Sprintf("requested plugin that is not installed: %s", culprit.Name))
+		return BadUsage
 	}
 
 	var runCount int
-	for _, pluginPkg := range plugins {
-		if !pluginPkg.Requested {
-			continue
-		}
+	for _, pluginPkg := range toRun {
 		serviceName := pluginPkg.ServiceTarget
-		if !pluginPkg.Installed {
-			logger.Error(fmt.Sprintf("requested plugin that is not installed: %s", pluginPkg.Name))
-			return BadUsage
-		}
 		runCount++
 		client := newClient(pluginPkg.Command, logger)
 		var rpcClient hcplugin.ClientProtocol

--- a/command/run_test.go
+++ b/command/run_test.go
@@ -26,3 +26,98 @@ func TestMergeExitCode(t *testing.T) {
 		})
 	}
 }
+
+// TestPlanRun covers Run's selection logic (which plugins execute and the
+// early-exit codes) directly, without spawning plugin subprocesses or mocking
+// the go-plugin RPC chain. The subprocess execution itself stays a thin shell
+// in Run around this decision.
+func TestPlanRun(t *testing.T) {
+	pkg := func(name string, installed, requested bool) *PluginPkg {
+		return &PluginPkg{Name: name, Installed: installed, Requested: requested}
+	}
+
+	tests := []struct {
+		name        string
+		plugins     []*PluginPkg
+		wantRun     []string // plugin names expected in toRun, in order
+		wantExit    int
+		wantCulprit string // "" when no culprit expected
+	}{
+		{
+			name:     "empty list returns NoTests",
+			plugins:  nil,
+			wantRun:  nil,
+			wantExit: NoTests,
+		},
+		{
+			name:     "only non-requested plugins run nothing",
+			plugins:  []*PluginPkg{pkg("acme/installed-only", true, false)},
+			wantRun:  nil,
+			wantExit: 0,
+		},
+		{
+			name:     "requested and installed is selected",
+			plugins:  []*PluginPkg{pkg("acme/scanner", true, true)},
+			wantRun:  []string{"acme/scanner"},
+			wantExit: 0,
+		},
+		{
+			name:        "requested but not installed returns BadUsage",
+			plugins:     []*PluginPkg{pkg("acme/missing", false, true)},
+			wantRun:     nil,
+			wantExit:    BadUsage,
+			wantCulprit: "acme/missing",
+		},
+		{
+			name: "mixed list selects only requested-and-installed, in order",
+			plugins: []*PluginPkg{
+				pkg("acme/local-only", true, false),
+				pkg("acme/scanner", true, true),
+				pkg("acme/second", true, true),
+			},
+			wantRun:  []string{"acme/scanner", "acme/second"},
+			wantExit: 0,
+		},
+		{
+			name: "not-installed requested plugin aborts before running earlier ones",
+			plugins: []*PluginPkg{
+				pkg("acme/scanner", true, true),
+				pkg("acme/missing", false, true),
+			},
+			wantRun:     nil,
+			wantExit:    BadUsage,
+			wantCulprit: "acme/missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toRun, earlyExit, culprit := planRun(tt.plugins)
+
+			if earlyExit != tt.wantExit {
+				t.Errorf("earlyExit = %d, want %d", earlyExit, tt.wantExit)
+			}
+
+			gotNames := make([]string, len(toRun))
+			for i, p := range toRun {
+				gotNames[i] = p.Name
+			}
+			if len(gotNames) != len(tt.wantRun) {
+				t.Fatalf("toRun = %v, want %v", gotNames, tt.wantRun)
+			}
+			for i := range gotNames {
+				if gotNames[i] != tt.wantRun[i] {
+					t.Errorf("toRun[%d] = %q, want %q", i, gotNames[i], tt.wantRun[i])
+				}
+			}
+
+			gotCulprit := ""
+			if culprit != nil {
+				gotCulprit = culprit.Name
+			}
+			if gotCulprit != tt.wantCulprit {
+				t.Errorf("culprit = %q, want %q", gotCulprit, tt.wantCulprit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What/Why

`Run` had no test coverage of its plugin-selection logic, which is exactly where the finding #3 regression (executing installed-but-not-requested plugins) slipped through in #242. This adds that coverage by extracting the decision into a pure `planRun` function instead of mocking the plugin subprocess chain.

`planRun(plugins)` returns the requested-and-installed plugins to execute (in order) plus any early-exit code (`NoTests` / `BadUsage`). `Run` becomes a thin shell that spawns subprocesses around that decision. No go-plugin fakes, no injectable client seam.

## Proof it works

`TestPlanRun` table-tests the selection directly (no subprocesses, no RPC mocks): empty list, only-non-requested, requested+installed, requested+not-installed, mixed ordering, and fail-fast on a not-installed plugin. `go build`, `go vet`, `go test ./command/...`, and `golangci-lint run` are all clean.

## Risk + AI role

Low. Pure refactor of selection logic plus tests; the subprocess execution path is unchanged. AI-assisted (Claude Opus 4.8).

One intentional behavior change: `planRun` validates the whole list up front, so a config that requests an uninstalled plugin now returns `BadUsage` before any plugin runs. Previously a requested+installed plugin earlier in the (map-ordered, so non-deterministic) slice could execute before the abort. The new behavior is deterministic fail-fast.

## Review focus

1. **The behavior change** above: confirm fail-before-running is acceptable versus the prior non-deterministic partial-execution.
2. **Selection vs execution split**: `planRun` owns "which plugins and what early exit"; `Run` owns subprocess I/O and exit-code merging. Confirm nothing selection-related leaked back into the loop.
