### PR TITLE
refactor(ai): generalize evidence types and bump go-gemara to v0.7.0

### DIFF
--- a/ai/evidence.go
+++ b/ai/evidence.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	gemara "github.com/gemaraproj/go-gemara"
 	sdkconfig "github.com/privateerproj/privateer-sdk/config"
 )
 
@@ -47,12 +48,18 @@ type PacketAttempt struct {
 	Outcome      string
 	AttemptStage string
 
-	// Result, Confidence, and Verdict are the caller-domain summary fields
-	// rendered into assessment.json. They are strings so the SDK does not
-	// depend on any particular verdict type.
-	Result     string
-	Confidence string
-	Verdict    string
+	// StepResult and StepConfidence carry the gemara-typed assessment
+	// outcome from the evaluation step. WritePacket renders their
+	// .String() representations into assessment.json so the on-disk
+	// format stays human-readable. Zero values (NotRun / Undetermined)
+	// are treated as unset and omitted from the JSON output.
+	StepResult     gemara.Result
+	StepConfidence gemara.ConfidenceLevel
+
+	// Verdict comes from the AI model's structured response (e.g.
+	// "pass"). It is the raw AI output, distinct from StepResult which
+	// is the evaluation pipeline's typed outcome.
+	Verdict string
 
 	// Reasoning and EvidenceLocation come from the parsed structured AI
 	// response. The writer sanitizes them using configured values and
@@ -60,11 +67,11 @@ type PacketAttempt struct {
 	Reasoning        string
 	EvidenceLocation string
 
-	// AssessmentMessage is the human-readable summary that the caller
-	// surfaces (e.g. in scanner logs). FailureMessage is derived from
-	// Failure when set.
-	AssessmentMessage string
-	Failure           error
+	// StepMessage is the human-readable summary that the caller surfaces
+	// (e.g. in scanner logs). FailureMessage is derived from Failure
+	// when set.
+	StepMessage string
+	Failure     error
 
 	// Provider interaction artifacts. The writer sanitizes prompt, evidence,
 	// and response content before persistence. Schema is copied for
@@ -226,9 +233,9 @@ func WritePacket(config sdkconfig.Config, attempt PacketAttempt) error {
 		FinishReason:      packetFinishReason(attempt.Response),
 		Outcome:           strings.TrimSpace(attempt.Outcome),
 		AttemptStage:      strings.TrimSpace(attempt.AttemptStage),
-		Result:            strings.TrimSpace(attempt.Result),
-		Confidence:        strings.TrimSpace(attempt.Confidence),
-		AssessmentMessage: sanitizer.RedactText(attempt.AssessmentMessage),
+		Result:            gemaraResultString(attempt.StepResult),
+		Confidence:        gemaraConfidenceString(attempt.StepConfidence),
+		AssessmentMessage: sanitizer.RedactText(attempt.StepMessage),
 		FailureMessage:    sanitizer.RedactText(errorMessage(attempt.Failure)),
 		Verdict:           strings.TrimSpace(attempt.Verdict),
 		Reasoning:         sanitizer.RedactText(attempt.Reasoning),
@@ -331,6 +338,20 @@ func packetDirectoryName(requestID string) string {
 		safe = safe[:48]
 	}
 	return base + "-" + safe
+}
+
+func gemaraResultString(r gemara.Result) string {
+	if r == gemara.NotRun {
+		return ""
+	}
+	return r.String()
+}
+
+func gemaraConfidenceString(c gemara.ConfidenceLevel) string {
+	if c == gemara.Undetermined {
+		return ""
+	}
+	return c.String()
 }
 
 func packetProvider(response *AnalyzeResponse, config Config) Provider {

--- a/ai/evidence.go
+++ b/ai/evidence.go
@@ -26,7 +26,7 @@ const DefaultPacketVersion = "1"
 // are intentionally generic so future AI-assisted controls (and future
 // providers) can reuse the same writer without modification.
 type PacketAttempt struct {
-	// ControlID is the OSPS control identifier (e.g. "OSPS-QA-06.02").
+	// ControlID is the catalog control identifier (e.g. "AC-01.02").
 	// Required: it becomes the parent directory under ai-evidence/.
 	ControlID string
 

--- a/ai/evidence_test.go
+++ b/ai/evidence_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	gemara "github.com/gemaraproj/go-gemara"
 	sdkconfig "github.com/privateerproj/privateer-sdk/config"
 )
 
@@ -43,12 +44,12 @@ func TestWritePacketSucceededAttempt(t *testing.T) {
 		RepositoryName:    "test-repo",
 		DefaultBranch:     "main",
 		CommitSHA:         "abc123def456",
-		Result:            "Passed",
-		Confidence:        "High",
+		StepResult:        gemara.Passed,
+		StepConfidence:    gemara.High,
 		Verdict:           "pass",
 		Reasoning:         "README explains contributors should run go test before opening a PR. Authorization: Bearer sk-live-1234567890abcdef",
 		EvidenceLocation:  "README#testing ghp_var_secret_123456",
-		AssessmentMessage: "[AI-Assisted] verdict=pass confidence=0.91",
+		StepMessage: "[AI-Assisted] verdict=pass confidence=0.91",
 		Prompt:            "You are assessing test execution documentation with super-secret-key.",
 		Schema: &Schema{
 			Name:        "test_execution_documentation_assessment",
@@ -180,7 +181,7 @@ func TestWritePacketFailedAttempt(t *testing.T) {
 		ControlID:         "CTL-QA-06.02",
 		Outcome:           "failed",
 		AttemptStage:      "provider_call",
-		AssessmentMessage: "Review project documentation to ensure it explains when and how tests are run",
+		StepMessage: "Review project documentation to ensure it explains when and how tests are run",
 		Failure:           errors.New("provider unavailable"),
 		Prompt:            "prompt",
 		Evidence:          "README\nbody",
@@ -212,6 +213,11 @@ func TestWritePacketFailedAttempt(t *testing.T) {
 	} {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("assessment.json missing %s; got %s", want, string(body))
+		}
+	}
+	for _, absent := range []string{`"result"`, `"confidence"`} {
+		if strings.Contains(string(body), absent) {
+			t.Fatalf("assessment.json should omit %s when step result/confidence are zero-valued; got %s", absent, string(body))
 		}
 	}
 }

--- a/ai/evidence_test.go
+++ b/ai/evidence_test.go
@@ -36,7 +36,7 @@ func TestWritePacketSucceededAttempt(t *testing.T) {
 	tempDir := t.TempDir()
 	config := newTestSDKConfig(t, tempDir)
 	attempt := PacketAttempt{
-		ControlID:         "OSPS-QA-06.02",
+		ControlID:         "CTL-QA-06.02",
 		Outcome:           "succeeded",
 		AttemptStage:      "assessment_completed",
 		RepositoryOwner:   "test-owner",
@@ -78,7 +78,7 @@ func TestWritePacketSucceededAttempt(t *testing.T) {
 		t.Fatalf("WritePacket: %v", err)
 	}
 
-	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "CTL-QA-06.02", "*"))
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestWritePacketSucceededAttempt(t *testing.T) {
 	assessmentText := string(assessmentBytes)
 	for _, want := range []string{
 		`"packet_version": "1"`,
-		`"control_id": "OSPS-QA-06.02"`,
+		`"control_id": "CTL-QA-06.02"`,
 		`"service_name": "my-scan"`,
 		`"repository_owner": "test-owner"`,
 		`"commit_sha": "abc123def456"`,
@@ -177,7 +177,7 @@ func TestWritePacketFailedAttempt(t *testing.T) {
 	config := newTestSDKConfig(t, tempDir)
 
 	attempt := PacketAttempt{
-		ControlID:         "OSPS-QA-06.02",
+		ControlID:         "CTL-QA-06.02",
 		Outcome:           "failed",
 		AttemptStage:      "provider_call",
 		AssessmentMessage: "Review project documentation to ensure it explains when and how tests are run",
@@ -191,7 +191,7 @@ func TestWritePacketFailedAttempt(t *testing.T) {
 		t.Fatalf("WritePacket: %v", err)
 	}
 
-	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "CTL-QA-06.02", "*"))
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testin
 	config.Vars["token"] = escapedSecret
 
 	attempt := PacketAttempt{
-		ControlID:       "OSPS-QA-06.02",
+		ControlID:       "CTL-QA-06.02",
 		Outcome:         "succeeded",
 		AttemptStage:    "assessment_completed",
 		RepositoryOwner: "test-owner",
@@ -250,7 +250,7 @@ func TestWritePacketFinalRedactionPassCoversMetadataSchemaAndDirectory(t *testin
 		t.Fatalf("WritePacket: %v", err)
 	}
 
-	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "OSPS-QA-06.02", "*"))
+	matches, err := filepath.Glob(filepath.Join(tempDir, "my-scan", "ai-evidence", "CTL-QA-06.02", "*"))
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestWritePacketNoopWhenWriteDisabled(t *testing.T) {
 	config := newTestSDKConfig(t, tempDir)
 	config.Write = false
 
-	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+	if err := WritePacket(config, PacketAttempt{ControlID: "CTL-QA-06.02"}); err != nil {
 		t.Fatalf("WritePacket: %v", err)
 	}
 	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
@@ -307,7 +307,7 @@ func TestWritePacketNoopWhenEvidenceWritingDisabled(t *testing.T) {
 	config := newTestSDKConfig(t, tempDir)
 	config.Vars["ai_write_evidence"] = false
 
-	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+	if err := WritePacket(config, PacketAttempt{ControlID: "CTL-QA-06.02"}); err != nil {
 		t.Fatalf("WritePacket: %v", err)
 	}
 	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
@@ -320,7 +320,7 @@ func TestWritePacketRejectsWrongTypedEvidenceWritingConfig(t *testing.T) {
 	config := newTestSDKConfig(t, tempDir)
 	config.Vars["ai_write_evidence"] = "true"
 
-	err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"})
+	err := WritePacket(config, PacketAttempt{ControlID: "CTL-QA-06.02"})
 	if err == nil {
 		t.Fatal("expected wrong-typed ai_write_evidence error, got nil")
 	}
@@ -339,7 +339,7 @@ func TestWritePacketNoopWhenAIUnconfigured(t *testing.T) {
 		"ai_write_evidence": true,
 	}
 
-	if err := WritePacket(config, PacketAttempt{ControlID: "OSPS-QA-06.02"}); err != nil {
+	if err := WritePacket(config, PacketAttempt{ControlID: "CTL-QA-06.02"}); err != nil {
 		t.Fatalf("WritePacket: %v", err)
 	}
 	if entries, _ := os.ReadDir(tempDir); len(entries) != 0 {
@@ -360,7 +360,7 @@ func TestWritePacketNoopWhenControlIDMissing(t *testing.T) {
 }
 
 func TestCreatePacketDirectoryFailsWhenPacketDirectoryExists(t *testing.T) {
-	packetDir := filepath.Join(t.TempDir(), "my-scan", "ai-evidence", "OSPS-QA-06.02", "packet")
+	packetDir := filepath.Join(t.TempDir(), "my-scan", "ai-evidence", "CTL-QA-06.02", "packet")
 	if err := createPacketDirectory(packetDir); err != nil {
 		t.Fatalf("createPacketDirectory first call: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/privateerproj/privateer-sdk
 go 1.26.2
 
 require (
-	github.com/gemaraproj/go-gemara v0.5.0
+	github.com/gemaraproj/go-gemara v0.7.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
-github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/gemaraproj/go-gemara v0.7.0 h1:cDIuKD03DF1bhrG3dmBoiJoF3h2mSMJ3YtDRr4LjvXE=
+github.com/gemaraproj/go-gemara v0.7.0/go.mod h1:h5Yepw+9Gww3x97Yk4X0pVnnci9S/W2Yo/66rp4WN54=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=


### PR DESCRIPTION
Relates to #231

## What/Why

Generalize the AI evidence package to be catalog-neutral and align with go-gemara v0.7.0. This PR removes OSPS-specific coupling from comments and test data, bumps go-gemara to v0.7.0 for EvidenceCollector/HasEvidence support (gemaraproj/go-gemara#80), and replaces loose string fields on PacketAttempt (Result, Confidence, AssessmentMessage) with gemara-typed equivalents (StepResult, StepConfidence, StepMessage) so downstream plugins pass typed values from the evaluation pipeline.

## Proof it works

All 12 test packages pass. Test data updated from "OSPS-QA-06.02" to generic "CTL-QA-06.02" control IDs. Zero-value omission explicitly tested (NotRun/Undetermined produce empty strings for JSON omitempty compat). JSON output format unchanged since gemara .String() returns the same human-readable values. go.sum checksums verified against the Go module proxy.

## Risk + AI role

Medium -- breaking API change for PacketAttempt callers (renamed fields with new types). All code AI-generated (Claude Opus 4.6) with human review.

## Review focus

1. Zero-value handling in gemaraResultString/gemaraConfidenceString: NotRun and Undetermined map to empty string for JSON omitempty. Confirm this is the right default vs recording "Not Run"/"Undetermined" explicitly.
2. Whether StepMessage naming is clear enough vs the old AssessmentMessage, and whether remaining OSPS references in test fixtures outside `ai/` need similar generalization.