### PR TITLE
chore(ci): update ospo-reusable-workflows to v1.2.1; enable release-only-with-label

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@6d7a83e6fc8275128984b0ed3defa4b8cdc40f85
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@7fc8753b3666b929250bb6241ce4b2d35f316a11 # v1.2.1
     with:
       config-name: release-drafter.yml
     secrets:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@6d7a83e6fc8275128984b0ed3defa4b8cdc40f85
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@7fc8753b3666b929250bb6241ce4b2d35f316a11 # v1.2.1
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
       attestations: write   # release_goreleaser, release_image: build provenance
       packages: write       # release_image: push container image (gated, but validated)
       discussions: write    # release_discussion: announcement (gated, defensive)
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@6d7a83e6fc8275128984b0ed3defa4b8cdc40f85 # v1.1.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@7fc8753b3666b929250bb6241ce4b2d35f316a11 # v1.2.1
     with:
       publish: true
       release-config-name: release-drafter.yml
+      release-only-with-label: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What/Why

Bump ospo-reusable-workflows from v1.1.0 to v1.2.1 across all three consuming workflows (release, auto-labeler, pr-title) and enable the new `release-only-with-label` flag so releases only trigger when the PR carries the appropriate label.

## Proof it works

All Go tests and vet pass (`make build`). Changes are YAML-only workflow config, so correctness will be validated on the next PR merge by GitHub Actions.

## Risk + AI role

Low -- workflow config bump with SHA pinning.

## Review focus

- Verify the SHA `7fc8753b3666b929250bb6241ce4b2d35f316a11` matches the upstream v1.2.1 tag.
- Confirm `release-only-with-label` behavior matches the team's release process expectations.