### PR TITLE
fix(command): de-scope run-only flags off the shared root

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -13,16 +13,26 @@ import (
 	"github.com/spf13/viper"
 )
 
-// SetBase sets the base flags for all commands.
+// SetBase sets the flags that are universal to every command. These are safe to
+// place on a shared root because they apply to all subcommands. Execution-only
+// flags live in SetRunFlags so their shorthands (e.g. -o) do not collide with
+// sibling subcommands such as generate-plugin's --output-dir.
 func SetBase(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("config", "c", "", "Configuration file, JSON or YAML (if omitted, falls back to ./config.yml then ~/.privateer/config.yml)")
 	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 
-	cmd.PersistentFlags().StringP("write-directory", "w", "evaluation_results", "Directory to write evaluation results to")
-	_ = viper.BindPFlag("write-directory", cmd.PersistentFlags().Lookup("write-directory"))
-
 	cmd.PersistentFlags().StringP("loglevel", "l", "error", "Log level (trace, debug, info, warn, error, off)")
 	_ = viper.BindPFlag("loglevel", cmd.PersistentFlags().Lookup("loglevel"))
+
+	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
+}
+
+// SetRunFlags registers the execution-specific flags on the command that runs a
+// plugin (the pvtr `run` command, or a plugin binary's root). These are kept off
+// the shared root so their shorthands cannot collide with other subcommands.
+func SetRunFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringP("write-directory", "w", "evaluation_results", "Directory to write evaluation results to")
+	_ = viper.BindPFlag("write-directory", cmd.PersistentFlags().Lookup("write-directory"))
 
 	cmd.PersistentFlags().StringP("service", "s", "", "Named service to execute from the config")
 	_ = viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
@@ -41,8 +51,6 @@ func SetBase(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolP("include-payload", "", false, "Include the raw evaluated payload in results output (large; useful for tracing)")
 	_ = viper.BindPFlag("include-payload", cmd.PersistentFlags().Lookup("include-payload"))
-
-	cmd.PersistentFlags().BoolP("help", "h", false, "Give me a heading! Help for the specified command")
 }
 
 // ReadConfig reads the configuration file. If --config is explicitly provided,

--- a/command/base_scope_test.go
+++ b/command/base_scope_test.go
@@ -1,0 +1,97 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// universalFlags are the flags that apply to every command and therefore
+// belong on the shared root via SetBase.
+var universalFlags = []string{"config", "loglevel"}
+
+// runScopedFlags are execution-specific flags that only make sense for a run.
+// They must not leak onto the shared root, where their shorthands can collide
+// with sibling subcommands (e.g. -o vs generate-plugin's --output-dir).
+var runScopedFlags = map[string]string{
+	"output":          "o",
+	"write-directory": "w",
+	"service":         "s",
+	"test-suites":     "t",
+	"silent":          "",
+	"write":           "",
+	"include-payload": "",
+}
+
+// TestSetBase_RegistersUniversalFlags asserts SetBase keeps the truly universal
+// flags on the command it is given.
+func TestSetBase_RegistersUniversalFlags(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "test"}
+	SetBase(cmd)
+
+	for _, name := range universalFlags {
+		if cmd.PersistentFlags().Lookup(name) == nil {
+			t.Errorf("expected universal flag %q to be registered by SetBase", name)
+		}
+	}
+}
+
+// TestSetBase_DoesNotRegisterRunScopedFlags asserts SetBase no longer leaks the
+// run-specific flags onto the command. Leaking -o (output) onto a shared root
+// is what caused the cobra shorthand-collision panic in generate-plugin.
+func TestSetBase_DoesNotRegisterRunScopedFlags(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "test"}
+	SetBase(cmd)
+
+	for name := range runScopedFlags {
+		if cmd.PersistentFlags().Lookup(name) != nil {
+			t.Errorf("run-specific flag %q should not be registered by SetBase", name)
+		}
+	}
+}
+
+// TestSetRunFlags_RegistersRunScopedFlags asserts the run-specific flags, with
+// their expected shorthands, live on the run command instead.
+func TestSetRunFlags_RegistersRunScopedFlags(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "run"}
+	SetRunFlags(cmd)
+
+	for name, short := range runScopedFlags {
+		flag := cmd.PersistentFlags().Lookup(name)
+		if flag == nil {
+			t.Errorf("expected run flag %q to be registered by SetRunFlags", name)
+			continue
+		}
+		if flag.Shorthand != short {
+			t.Errorf("flag %q: expected shorthand %q, got %q", name, short, flag.Shorthand)
+		}
+	}
+}
+
+// TestSetBase_NoShorthandCollisionWithSubcommand is the regression guard for the
+// generate-plugin panic. When SetBase is applied to a shared root and a
+// subcommand claims -o for its own flag, cobra merges the parent's persistent
+// flags at Execute time; a duplicate -o shorthand would panic. With output
+// de-scoped off SetBase, the two coexist.
+func TestSetBase_NoShorthandCollisionWithSubcommand(t *testing.T) {
+	resetViper()
+	root := &cobra.Command{Use: "pvtr"}
+	SetBase(root)
+
+	sub := &cobra.Command{Use: "generate-plugin", Run: func(*cobra.Command, []string) {}}
+	sub.Flags().StringP("output-dir", "o", "generated-plugin/", "")
+	root.AddCommand(sub)
+	root.SetArgs([]string{"generate-plugin"})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic from -o shorthand collision: %v", r)
+		}
+	}()
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error executing subcommand: %v", err)
+	}
+}

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -39,6 +39,7 @@ func NewPluginCommands(pluginName, buildVersion, buildGitCommitHash, buildTime s
 		versionCommand(buildVersion, buildGitCommitHash, buildTime))
 
 	SetBase(runCmd)
+	SetRunFlags(runCmd)
 	return runCmd
 }
 


### PR DESCRIPTION
## What/Why

`SetBase` registered execution-only flags (including `--output`/`-o`) as *persistent* flags on whatever command it decorates. On a shared root that leaks `-o` onto every subcommand, colliding with a sibling's `-o` and panicking cobra. This split keeps only truly universal flags (`config`, `loglevel`, `help`) in `SetBase` and moves run-only flags into a new `SetRunFlags`.

Unblocks the `privateer` CLI, whose `generate-plugin --output-dir` (`-o`) panicked once the SDK root carried `-o` (privateerproj/privateer#272).

## Proof it works

New tests cover the split and a regression guard proving no `-o` collision when a `SetBase` root has a subcommand claiming `-o`. `go test ./...` and `golangci-lint` pass. Verified end-to-end against a local `pvtr` build: `generate-plugin` returns proper exit codes (4/4/3/0/1) instead of panicking, and `--output` remains available on `run`.

## Risk + AI role

Low -- flag registration only; `viper` binds are unchanged so every `viper.Get*` read still resolves regardless of which command owns the flag.

## Review focus

- The universal vs run-scoped partition: `config`/`loglevel` universal; `output`, `write-directory`, `service`, `test-suites`, `silent`, `write`, `include-payload` run-only.
- `NewPluginCommands` now calls both `SetBase` and `SetRunFlags`, so plugin binaries keep every flag on their run root (no behavior change for plugins).