### PR TITLE
feat(pluginkit): add `pvtr benchmark` instrumentation and cmd

### DIFF
--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -133,6 +133,13 @@ func isPluginSource(dir string) bool {
 // report it wrote. Failed controls are not errors — benchmarking a failing run
 // is valid — so the plugin's exit code is returned alongside the report.
 func runBenchmark(binPath, service, writeDir string, payloadOnly bool) (*pluginkit.BenchmarkReport, int, error) {
+	reportPath := filepath.Join(writeDir, service, pluginkit.BenchmarkFileName)
+	// A reused --write-directory may hold an earlier run's report; clear it so a
+	// run that produces none says so instead of presenting the stale file as its own.
+	if err := os.Remove(reportPath); err != nil && !os.IsNotExist(err) {
+		return nil, InternalError, fmt.Errorf("clearing previous benchmark report %s: %w", reportPath, err)
+	}
+
 	pluginCmd := exec.Command(binPath,
 		fmt.Sprintf("--config=%s", viper.GetString("config")),
 		fmt.Sprintf("--loglevel=%s", viper.GetString("loglevel")),
@@ -177,7 +184,6 @@ func runBenchmark(binPath, service, writeDir string, payloadOnly bool) (*plugink
 	exitCode, startErr := plugin.Start()
 	wallClock := time.Since(wallStart)
 
-	reportPath := filepath.Join(writeDir, service, pluginkit.BenchmarkFileName)
 	data, readErr := os.ReadFile(reportPath)
 	report, err := parseBenchmarkReport(data, readErr, startErr, reportPath)
 	if err != nil {

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -82,7 +82,9 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 				renderBenchmark(w, report, exitCode, writeDir)
 				_ = w.Flush()
 			}
-			return nil
+			// Reported after the breakdown, not instead of it: a broken run's
+			// timings are still worth reading while diagnosing the breakage.
+			return benchmarkRunError(exitCode)
 		},
 	}
 	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (required)")
@@ -90,6 +92,17 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 	benchmarkCmd.Flags().StringVarP(&writeDir, "write-directory", "w", "", "Directory for the run's results and report (default: a temp directory)")
 	benchmarkCmd.Flags().BoolVar(&payloadOnly, "payload-only", false, "Stop after payload retrieval and time only the loader (skip assessment steps)")
 	return benchmarkCmd
+}
+
+// benchmarkRunError fails the benchmark when the plugin itself broke. Failed
+// controls are a valid thing to benchmark, so TestFail stays a success here;
+// only a plugin that could not complete invalidates the numbers.
+func benchmarkRunError(exitCode int) error {
+	switch exitCode {
+	case InternalError, BadUsage:
+		return fmt.Errorf("plugin exited %d — benchmark may be incomplete", exitCode)
+	}
+	return nil
 }
 
 // resolvePluginBinary validates the path and returns it absolute, so exec never

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -20,6 +20,12 @@ import (
 	"github.com/privateerproj/privateer-sdk/shared"
 )
 
+type benchmarkRow struct {
+	label      string
+	detail     string
+	durationNs int64
+}
+
 // benchmarkCmd returns the `pvtr benchmark` command. It takes the plugin binary
 // path directly (not a manifest coordinate, so a freshly-built plugin needs no
 // install), runs it once in benchmark mode, and renders the report the plugin
@@ -41,11 +47,7 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 			"Takes the path to a compiled plugin binary — the plugin runs as a separate " +
 			"process, so build it first (`make build`, or `go build -o <name> .`) and pass " +
 			"the resulting executable. The named --service must exist in the config file so " +
-			"the plugin has its vars, catalogs, and applicability.\n\n" +
-			"Use --payload-only to stop after payload retrieval and time just the loader — " +
-			"assessment steps consume the payload, so they cannot run without it and are " +
-			"skipped. Use --json for a machine-readable report suitable for diffing plugin " +
-			"versions in CI.",
+			"the plugin has its vars, catalogs, and applicability.",
 		Args: cobra.ExactArgs(1),
 		// runtime failures shouldn't reprint usage text
 		SilenceUsage: true,
@@ -84,7 +86,7 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 		},
 	}
 	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (required)")
-	benchmarkCmd.Flags().BoolVar(&jsonOut, "json", false, "Emit the machine-readable benchmark report as JSON")
+	benchmarkCmd.Flags().BoolVar(&jsonOut, "json", false, "Emit the machine-readable benchmark report as JSON (for diffing runs in CI)")
 	benchmarkCmd.Flags().StringVarP(&writeDir, "write-directory", "w", "", "Directory for the run's results and report (default: a temp directory)")
 	benchmarkCmd.Flags().BoolVar(&payloadOnly, "payload-only", false, "Stop after payload retrieval and time only the loader (skip assessment steps)")
 	return benchmarkCmd
@@ -137,7 +139,10 @@ func runBenchmark(binPath, service, writeDir string, payloadOnly bool) (*plugink
 		fmt.Sprintf("--service=%s", service),
 		fmt.Sprintf("--write-directory=%s", writeDir),
 	)
-	// plugins have no --benchmark flag; instrumentation travels as env
+	// Deliberately env, not a flag: viper's AutomaticEnv maps these to the
+	// benchmark / benchmark-payload-only config keys, so they follow normal
+	// precedence without adding harness-only instrumentation to the flag set in
+	// base.go — which every plugin would then advertise in its --help.
 	pluginCmd.Env = append(os.Environ(), "PVTR_BENCHMARK=true")
 	if payloadOnly {
 		pluginCmd.Env = append(pluginCmd.Env, "PVTR_BENCHMARK_PAYLOAD_ONLY=true")
@@ -182,30 +187,20 @@ func runBenchmark(binPath, service, writeDir string, payloadOnly bool) (*plugink
 	return report, exitCode, nil
 }
 
-// parseBenchmarkReport returns the report or the best explanation of its
-// absence. Split from runBenchmark so the diagnosis is unit-testable without
-// spawning a plugin. readErr is from reading the file, startErr from the
-// plugin's Start; a missing report means a plugin failure or an SDK too old to
-// instrument.
+// parseBenchmarkReport returns the report or the best explanation of its absence.
 func parseBenchmarkReport(data []byte, readErr, startErr error, reportPath string) (*pluginkit.BenchmarkReport, error) {
 	if readErr != nil {
 		if startErr != nil {
 			return nil, fmt.Errorf("plugin run failed before producing a benchmark report: %w", startErr)
 		}
 		return nil, fmt.Errorf(
-			"the run completed but no benchmark report was found at %s — the plugin was likely built against a privateer-sdk without benchmark instrumentation; rebuild it with a newer SDK", reportPath)
+			"the run completed but no benchmark report was found at %s — the plugin may not have benchmark instrumentation; rebuilding it against a newer privateer-sdk will add it", reportPath)
 	}
 	report := &pluginkit.BenchmarkReport{}
 	if err := json.Unmarshal(data, report); err != nil {
 		return nil, fmt.Errorf("parsing benchmark report %s: %w", reportPath, err)
 	}
 	return report, nil
-}
-
-type benchmarkRow struct {
-	label      string
-	detail     string
-	durationNs int64
 }
 
 // renderBenchmark prints the breakdown: every segment sorted by cost, with a
@@ -280,7 +275,8 @@ func renderBenchmark(w Writer, report *pluginkit.BenchmarkReport, exitCode int, 
 	}
 }
 
-// formatNs renders a duration human-readably, rounded but sub-ms accurate.
+// formatNs renders a duration human-readably, keeping precision proportional to
+// magnitude so a long payload fetch and a fast step stay comparable at a glance.
 func formatNs(ns int64) time.Duration {
 	d := time.Duration(ns)
 	switch {

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -74,7 +74,7 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("marshaling benchmark report: %w", err)
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), string(data))
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
 			} else {
 				w := writerFn()
 				renderBenchmark(w, report, exitCode, writeDir)
@@ -215,13 +215,13 @@ func renderBenchmark(w Writer, report *pluginkit.BenchmarkReport, exitCode int, 
 	if version == "" {
 		version = "unversioned"
 	}
-	fmt.Fprintf(w, "Benchmark: %s (%s) service=%s\n", report.PluginName, version, report.ServiceName)
-	fmt.Fprintf(w, "Wall clock %v; plugin total %v; exit code %d; results in %s\n",
+	_, _ = fmt.Fprintf(w, "Benchmark: %s (%s) service=%s\n", report.PluginName, version, report.ServiceName)
+	_, _ = fmt.Fprintf(w, "Wall clock %v; plugin total %v; exit code %d; results in %s\n",
 		formatNs(report.WallClockNs), formatNs(report.TotalDurationNs), exitCode, writeDir)
 	if report.APICalls != nil {
-		fmt.Fprintf(w, "API calls reported by payload: %d\n", *report.APICalls)
+		_, _ = fmt.Fprintf(w, "API calls reported by payload: %d\n", *report.APICalls)
 	}
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 
 	var rows []benchmarkRow
 	var attributedNs int64
@@ -274,9 +274,9 @@ func renderBenchmark(w Writer, report *pluginkit.BenchmarkReport, exitCode int, 
 		})
 	}
 
-	fmt.Fprintf(w, "SEGMENT\tFUNCTION\tDURATION\tSHARE\n")
+	_, _ = fmt.Fprintln(w, "SEGMENT\tFUNCTION\tDURATION\tSHARE")
 	for _, row := range rows {
-		fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", row.label, row.detail, formatNs(row.durationNs), share(row.durationNs, report.TotalDurationNs))
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", row.label, row.detail, formatNs(row.durationNs), share(row.durationNs, report.TotalDurationNs))
 	}
 }
 

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -1,0 +1,311 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	hcplugin "github.com/hashicorp/go-plugin"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/privateerproj/privateer-sdk/pluginkit"
+	"github.com/privateerproj/privateer-sdk/shared"
+)
+
+// benchmarkCmd returns the `pvtr benchmark` command. It takes the plugin binary
+// path directly (not a manifest coordinate, so a freshly-built plugin needs no
+// install), runs it once in benchmark mode, and renders the report the plugin
+// writes. An older SDK without instrumentation produces no report.
+func benchmarkCmd(writerFn func() Writer) *cobra.Command {
+	var (
+		service     string
+		jsonOut     bool
+		writeDir    string
+		payloadOnly bool
+	)
+
+	benchmarkCmd := &cobra.Command{
+		Use:   "benchmark <plugin-binary>",
+		Short: "Time a plugin's payload retrieval and every step, and print a cost breakdown.",
+		Long: "Run a plugin once with benchmark instrumentation enabled and print a breakdown " +
+			"of where the time went: payload retrieval (the loader) separately from each " +
+			"individual assessment step, using monotonic sub-millisecond durations.\n\n" +
+			"Takes the path to a compiled plugin binary — the plugin runs as a separate " +
+			"process, so build it first (`make build`, or `go build -o <name> .`) and pass " +
+			"the resulting executable. The named --service must exist in the config file so " +
+			"the plugin has its vars, catalogs, and applicability.\n\n" +
+			"Use --payload-only to stop after payload retrieval and time just the loader — " +
+			"assessment steps consume the payload, so they cannot run without it and are " +
+			"skipped. Use --json for a machine-readable report suitable for diffing plugin " +
+			"versions in CI.",
+		Args: cobra.ExactArgs(1),
+		// runtime failures shouldn't reprint usage text
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if service == "" {
+				return fmt.Errorf("--service is required: the plugin needs a configured service to evaluate")
+			}
+			binPath, err := resolvePluginBinary(args[0])
+			if err != nil {
+				return err
+			}
+			if writeDir == "" {
+				writeDir, err = os.MkdirTemp("", "pvtr-benchmark-")
+				if err != nil {
+					return fmt.Errorf("creating benchmark output directory: %w", err)
+				}
+			}
+
+			report, exitCode, err := runBenchmark(binPath, service, writeDir, payloadOnly)
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				data, err := json.MarshalIndent(report, "", "  ")
+				if err != nil {
+					return fmt.Errorf("marshaling benchmark report: %w", err)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			} else {
+				w := writerFn()
+				renderBenchmark(w, report, exitCode, writeDir)
+				_ = w.Flush()
+			}
+			return nil
+		},
+	}
+	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (required)")
+	benchmarkCmd.Flags().BoolVar(&jsonOut, "json", false, "Emit the machine-readable benchmark report as JSON")
+	benchmarkCmd.Flags().StringVarP(&writeDir, "write-directory", "w", "", "Directory for the run's results and report (default: a temp directory)")
+	benchmarkCmd.Flags().BoolVar(&payloadOnly, "payload-only", false, "Stop after payload retrieval and time only the loader (skip assessment steps)")
+	return benchmarkCmd
+}
+
+// resolvePluginBinary validates the path and returns it absolute, so exec never
+// does a $PATH lookup for a bare name.
+func resolvePluginBinary(arg string) (string, error) {
+	binPath, err := filepath.Abs(arg)
+	if err != nil {
+		return "", fmt.Errorf("resolving plugin binary path %q: %w", arg, err)
+	}
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return "", fmt.Errorf("plugin binary %q: %w", arg, err)
+	}
+	if info.IsDir() {
+		// most likely mistake: pointing at the source tree instead of the binary
+		if isPluginSource(binPath) {
+			return "", fmt.Errorf(
+				"%q is a plugin source directory, not a compiled binary — build it first (`make build`, or `go build -o <name> .`) and pass the resulting executable", arg)
+		}
+		return "", fmt.Errorf("plugin binary %q is a directory, not an executable", arg)
+	}
+	// Windows has no exec bit; let the exec attempt be the arbiter there.
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return "", fmt.Errorf("plugin binary %q is not executable", arg)
+	}
+	return binPath, nil
+}
+
+// isPluginSource reports whether dir looks like a Go plugin source tree, so the
+// error can point at the build step.
+func isPluginSource(dir string) bool {
+	for _, marker := range []string{"go.mod", "main.go"} {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// runBenchmark executes the plugin once in benchmark mode and returns the
+// report it wrote. Failed controls are not errors — benchmarking a failing run
+// is valid — so the plugin's exit code is returned alongside the report.
+func runBenchmark(binPath, service, writeDir string, payloadOnly bool) (*pluginkit.BenchmarkReport, int, error) {
+	pluginCmd := exec.Command(binPath,
+		fmt.Sprintf("--config=%s", viper.GetString("config")),
+		fmt.Sprintf("--loglevel=%s", viper.GetString("loglevel")),
+		fmt.Sprintf("--service=%s", service),
+		fmt.Sprintf("--write-directory=%s", writeDir),
+	)
+	// plugins have no --benchmark flag; instrumentation travels as env
+	pluginCmd.Env = append(os.Environ(), "PVTR_BENCHMARK=true")
+	if payloadOnly {
+		pluginCmd.Env = append(pluginCmd.Env, "PVTR_BENCHMARK_PAYLOAD_ONLY=true")
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "benchmark",
+		Level:  hclog.LevelFromString(viper.GetString("loglevel")),
+		Output: os.Stderr,
+	})
+	client := hcplugin.NewClient(&hcplugin.ClientConfig{
+		HandshakeConfig: shared.GetHandshakeConfig(),
+		Plugins:         map[string]hcplugin.Plugin{shared.PluginName: &shared.Plugin{}},
+		Cmd:             pluginCmd,
+		Logger:          logger,
+		SyncStdout:      os.Stdout,
+		SyncStderr:      os.Stderr,
+	})
+	defer client.Kill()
+
+	// brackets startup, handshake, and RPC — what the plugin-side total can't see
+	wallStart := time.Now()
+	rpcClient, err := client.Client()
+	if err != nil {
+		return nil, InternalError, fmt.Errorf("initializing plugin RPC client: %w", err)
+	}
+	rawPlugin, err := rpcClient.Dispense(shared.PluginName)
+	if err != nil {
+		return nil, InternalError, fmt.Errorf("dispensing plugin RPC client: %w", err)
+	}
+	plugin := rawPlugin.(shared.Pluginer)
+	exitCode, startErr := plugin.Start()
+	wallClock := time.Since(wallStart)
+
+	reportPath := filepath.Join(writeDir, service, pluginkit.BenchmarkFileName)
+	data, readErr := os.ReadFile(reportPath)
+	report, err := parseBenchmarkReport(data, readErr, startErr, reportPath)
+	if err != nil {
+		return nil, exitCode, err
+	}
+	report.WallClockNs = wallClock.Nanoseconds()
+	return report, exitCode, nil
+}
+
+// parseBenchmarkReport returns the report or the best explanation of its
+// absence. Split from runBenchmark so the diagnosis is unit-testable without
+// spawning a plugin. readErr is from reading the file, startErr from the
+// plugin's Start; a missing report means a plugin failure or an SDK too old to
+// instrument.
+func parseBenchmarkReport(data []byte, readErr, startErr error, reportPath string) (*pluginkit.BenchmarkReport, error) {
+	if readErr != nil {
+		if startErr != nil {
+			return nil, fmt.Errorf("plugin run failed before producing a benchmark report: %w", startErr)
+		}
+		return nil, fmt.Errorf(
+			"the run completed but no benchmark report was found at %s — the plugin was likely built against a privateer-sdk without benchmark instrumentation; rebuild it with a newer SDK", reportPath)
+	}
+	report := &pluginkit.BenchmarkReport{}
+	if err := json.Unmarshal(data, report); err != nil {
+		return nil, fmt.Errorf("parsing benchmark report %s: %w", reportPath, err)
+	}
+	return report, nil
+}
+
+type benchmarkRow struct {
+	label      string
+	detail     string
+	durationNs int64
+}
+
+// renderBenchmark prints the breakdown: every segment sorted by cost, with a
+// share-of-total column against the plugin-side total.
+func renderBenchmark(w Writer, report *pluginkit.BenchmarkReport, exitCode int, writeDir string) {
+	version := report.PluginVersion
+	if version == "" {
+		version = "unversioned"
+	}
+	fmt.Fprintf(w, "Benchmark: %s (%s) service=%s\n", report.PluginName, version, report.ServiceName)
+	fmt.Fprintf(w, "Wall clock %v; plugin total %v; exit code %d; results in %s\n",
+		formatNs(report.WallClockNs), formatNs(report.TotalDurationNs), exitCode, writeDir)
+	if report.APICalls != nil {
+		fmt.Fprintf(w, "API calls reported by payload: %d\n", *report.APICalls)
+	}
+	fmt.Fprintln(w)
+
+	var rows []benchmarkRow
+	var attributedNs int64
+	for _, l := range report.Loaders {
+		rows = append(rows, benchmarkRow{
+			label:      "payload retrieval (" + l.Scope + ")",
+			detail:     shortFuncName(l.Func),
+			durationNs: l.DurationNs,
+		})
+		attributedNs += l.DurationNs
+	}
+	multiSuite := len(report.Suites) > 1
+	for _, s := range report.Suites {
+		// suite duration minus its steps is evaluation-loop overhead; give it its
+		// own row so it isn't mislabeled as unattributed startup/writing cost
+		var suiteStepsNs int64
+		for _, st := range s.Steps {
+			suiteStepsNs += st.DurationNs
+		}
+		if overhead := s.DurationNs - suiteStepsNs; overhead > 0 {
+			rows = append(rows, benchmarkRow{
+				label:      "evaluation overhead (" + s.CatalogId + ")",
+				detail:     "applicability, aggregation, logging",
+				durationNs: overhead,
+			})
+			attributedNs += overhead
+		}
+		for _, st := range s.Steps {
+			label := st.RequirementId
+			if multiSuite {
+				label = s.CatalogId + " " + label
+			}
+			if st.StepIndex > 0 {
+				label = fmt.Sprintf("%s step[%d]", label, st.StepIndex)
+			}
+			rows = append(rows, benchmarkRow{
+				label:      label,
+				detail:     shortFuncName(st.Step),
+				durationNs: st.DurationNs,
+			})
+			attributedNs += st.DurationNs
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].durationNs > rows[j].durationNs })
+	if unattributed := report.TotalDurationNs - attributedNs; unattributed > 0 {
+		rows = append(rows, benchmarkRow{
+			label:      "unattributed",
+			detail:     "config, catalog parsing, result writing",
+			durationNs: unattributed,
+		})
+	}
+
+	fmt.Fprintf(w, "SEGMENT\tFUNCTION\tDURATION\tSHARE\n")
+	for _, row := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", row.label, row.detail, formatNs(row.durationNs), share(row.durationNs, report.TotalDurationNs))
+	}
+}
+
+// formatNs renders a duration human-readably, rounded but sub-ms accurate.
+func formatNs(ns int64) time.Duration {
+	d := time.Duration(ns)
+	switch {
+	case d >= time.Second:
+		return d.Round(10 * time.Millisecond)
+	case d >= time.Millisecond:
+		return d.Round(100 * time.Microsecond)
+	case d >= time.Microsecond:
+		return d.Round(time.Microsecond)
+	default:
+		return d // sub-µs: exact ns, never a misleading 0
+	}
+}
+
+func share(part, total int64) string {
+	if total <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", float64(part)/float64(total)*100)
+}
+
+// shortFuncName trims a function symbol to its last path segment (package.Func).
+func shortFuncName(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
+}

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -217,3 +217,30 @@ func TestRunBenchmark_ClearsStaleReport(t *testing.T) {
 		t.Errorf("stale report survived the run: %s", data)
 	}
 }
+
+// Which plugin outcomes invalidate a benchmark: a run that broke does, a run
+// whose controls merely failed does not.
+func TestBenchmarkRunError(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		exitCode int
+		wantErr  bool
+	}{
+		{"passing run", TestPass, false},
+		{"failed controls are still worth benchmarking", TestFail, false},
+		{"no tests", NoTests, false},
+		{"aborted", Aborted, false},
+		{"internal error invalidates the numbers", InternalError, true},
+		{"bad usage invalidates the numbers", BadUsage, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := benchmarkRunError(tc.exitCode)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected exit code %d to fail the benchmark", tc.exitCode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected exit code %d to succeed, got: %v", tc.exitCode, err)
+			}
+		})
+	}
+}

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -188,3 +188,32 @@ func TestRenderBenchmark(t *testing.T) {
 		t.Errorf("expected rows sorted by cost (loader < slow < fast), got positions %d, %d, %d\n---\n%s", loaderIdx, slowIdx, fastIdx, out)
 	}
 }
+
+// A reused --write-directory must not let a previous run's report be presented
+// as the current run's result.
+func TestRunBenchmark_ClearsStaleReport(t *testing.T) {
+	writeDir := t.TempDir()
+	service := "test-service"
+
+	reportPath := filepath.Join(writeDir, service, pluginkit.BenchmarkFileName)
+	if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+		t.Fatalf("seeding report dir: %v", err)
+	}
+	stale := []byte(`{"schema":"privateer-benchmark/v1","plugin-name":"stale-run"}`)
+	if err := os.WriteFile(reportPath, stale, 0o640); err != nil {
+		t.Fatalf("seeding stale report: %v", err)
+	}
+
+	// The binary does not exist, so this run produces no report of its own.
+	report, _, err := runBenchmark(filepath.Join(writeDir, "no-such-plugin"), service, writeDir, false)
+	if err == nil {
+		t.Fatalf("expected an error for a failed run, got report %+v", report)
+	}
+	if report != nil {
+		t.Errorf("expected no report from a failed run, got %+v", report)
+	}
+	if _, statErr := os.Stat(reportPath); !os.IsNotExist(statErr) {
+		data, _ := os.ReadFile(reportPath)
+		t.Errorf("stale report survived the run: %s", data)
+	}
+}

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -1,0 +1,187 @@
+package harness
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/privateerproj/privateer-sdk/pluginkit"
+)
+
+// benchBufWriter is a minimal command.Writer capturing output for assertions.
+type benchBufWriter struct{ bytes.Buffer }
+
+func (b *benchBufWriter) Flush() error { return nil }
+
+func TestGetBenchmarkCmd_Shape(t *testing.T) {
+	cmd := GetBenchmarkCmd(func() Writer { return &benchBufWriter{} })
+	if cmd.Use != "benchmark <plugin-binary>" {
+		t.Errorf("unexpected Use: %q", cmd.Use)
+	}
+	for _, flag := range []string{"service", "json", "write-directory", "payload-only"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected --%s flag", flag)
+		}
+	}
+}
+
+func TestBenchmarkCmd_RequiresService(t *testing.T) {
+	cmd := GetBenchmarkCmd(func() Writer { return &benchBufWriter{} })
+	cmd.SetArgs([]string{"/does/not/matter"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--service is required") {
+		t.Errorf("expected missing-service error, got: %v", err)
+	}
+}
+
+func TestResolvePluginBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := resolvePluginBinary(filepath.Join(tmpDir, "nope")); err == nil {
+			t.Error("expected error for missing binary")
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		if _, err := resolvePluginBinary(tmpDir); err == nil {
+			t.Error("expected error for directory")
+		}
+	})
+
+	t.Run("plugin source directory points at the build step", func(t *testing.T) {
+		srcDir := filepath.Join(tmpDir, "src")
+		if err := os.Mkdir(srcDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(srcDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := resolvePluginBinary(srcDir)
+		if err == nil || !strings.Contains(err.Error(), "source directory") {
+			t.Errorf("expected a source-directory diagnosis, got: %v", err)
+		}
+	})
+
+	t.Run("not executable", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "plain")
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolvePluginBinary(p); err == nil {
+			t.Error("expected error for non-executable file")
+		}
+	})
+
+	t.Run("executable resolves to absolute", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "bin")
+		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		resolved, err := resolvePluginBinary(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !filepath.IsAbs(resolved) {
+			t.Errorf("expected absolute path, got %q", resolved)
+		}
+	})
+}
+
+func TestParseBenchmarkReport(t *testing.T) {
+	readErr := os.ErrNotExist
+	startErr := errors.New("loader exploded")
+
+	t.Run("plugin failure explains a missing report", func(t *testing.T) {
+		_, err := parseBenchmarkReport(nil, readErr, startErr, "/x/benchmark.json")
+		if err == nil || !strings.Contains(err.Error(), "failed before producing a benchmark report") {
+			t.Errorf("expected the plugin failure to be surfaced, got: %v", err)
+		}
+		if !errors.Is(err, startErr) {
+			t.Errorf("expected the plugin's error to be wrapped, got: %v", err)
+		}
+	})
+
+	t.Run("missing report after a clean run points at an old SDK", func(t *testing.T) {
+		_, err := parseBenchmarkReport(nil, readErr, nil, "/x/benchmark.json")
+		if err == nil || !strings.Contains(err.Error(), "without benchmark instrumentation") {
+			t.Errorf("expected the old-SDK diagnosis, got: %v", err)
+		}
+	})
+
+	t.Run("malformed report", func(t *testing.T) {
+		_, err := parseBenchmarkReport([]byte("{not json"), nil, nil, "/x/benchmark.json")
+		if err == nil || !strings.Contains(err.Error(), "parsing benchmark report") {
+			t.Errorf("expected a parse error, got: %v", err)
+		}
+	})
+
+	t.Run("valid report", func(t *testing.T) {
+		report, err := parseBenchmarkReport([]byte(`{"plugin-name":"p","total-duration-ns":5}`), nil, nil, "/x/benchmark.json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if report.PluginName != "p" || report.TotalDurationNs != 5 {
+			t.Errorf("report not parsed: %+v", report)
+		}
+	})
+}
+
+func TestRenderBenchmark(t *testing.T) {
+	calls := 22
+	report := &pluginkit.BenchmarkReport{
+		Schema:        pluginkit.BenchmarkSchema,
+		PluginName:    "github-repo",
+		PluginVersion: "v1.0.0",
+		ServiceName:   "myrepo",
+		Loaders: []pluginkit.LoaderTiming{
+			{Scope: "orchestrator", Func: "github.com/ossf/pvtr-github-repo/data.Loader", DurationNs: 9_000_000_000},
+		},
+		Suites: []pluginkit.SuiteTiming{
+			{
+				CatalogId:  "osps-baseline",
+				DurationNs: 1_500_000_000,
+				Steps: []pluginkit.StepTiming{
+					{ControlId: "OSPS-AC-01", RequirementId: "OSPS-AC-01.01", StepIndex: 0, Step: "github.com/ossf/pvtr-github-repo/eval.SlowStep", Result: "Passed", DurationNs: 1_200_000_000},
+					{ControlId: "OSPS-AC-02", RequirementId: "OSPS-AC-02.01", StepIndex: 0, Step: "github.com/ossf/pvtr-github-repo/eval.FastStep", Result: "Failed", DurationNs: 5_000_000},
+				},
+			},
+		},
+		TotalDurationNs: 11_000_000_000,
+		APICalls:        &calls,
+		WallClockNs:     11_400_000_000,
+	}
+
+	w := &benchBufWriter{}
+	renderBenchmark(w, report, 0, "/tmp/out")
+	out := w.String()
+
+	for _, want := range []string{
+		"github-repo (v1.0.0) service=myrepo",
+		"payload retrieval (orchestrator)",
+		"data.Loader",
+		"OSPS-AC-01.01",
+		"eval.SlowStep",
+		"unattributed",
+		"API calls reported by payload: 22",
+		"81.8%", // loader share of 11s total
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\n---\n%s", want, out)
+		}
+	}
+
+	// Sorted by cost: the loader line must come before the slow step, which
+	// must come before the fast step.
+	loaderIdx := strings.Index(out, "payload retrieval")
+	slowIdx := strings.Index(out, "eval.SlowStep")
+	fastIdx := strings.Index(out, "eval.FastStep")
+	if !(loaderIdx < slowIdx && slowIdx < fastIdx) {
+		t.Errorf("expected rows sorted by cost (loader < slow < fast), got positions %d, %d, %d\n---\n%s", loaderIdx, slowIdx, fastIdx, out)
+	}
+}

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -181,7 +181,7 @@ func TestRenderBenchmark(t *testing.T) {
 	loaderIdx := strings.Index(out, "payload retrieval")
 	slowIdx := strings.Index(out, "eval.SlowStep")
 	fastIdx := strings.Index(out, "eval.FastStep")
-	if !(loaderIdx < slowIdx && slowIdx < fastIdx) {
+	if loaderIdx >= slowIdx || slowIdx >= fastIdx {
 		t.Errorf("expected rows sorted by cost (loader < slow < fast), got positions %d, %d, %d\n---\n%s", loaderIdx, slowIdx, fastIdx, out)
 	}
 }

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -109,8 +109,11 @@ func TestParseBenchmarkReport(t *testing.T) {
 
 	t.Run("missing report after a clean run points at an old SDK", func(t *testing.T) {
 		_, err := parseBenchmarkReport(nil, readErr, nil, "/x/benchmark.json")
-		if err == nil || !strings.Contains(err.Error(), "without benchmark instrumentation") {
-			t.Errorf("expected the old-SDK diagnosis, got: %v", err)
+		// assert on the remedy, not just the diagnosis — the actionable half is
+		// the part users need and the part easiest to lose in a reword
+		if err == nil || !strings.Contains(err.Error(), "benchmark instrumentation") ||
+			!strings.Contains(err.Error(), "rebuilding it against a newer privateer-sdk") {
+			t.Errorf("expected the old-SDK diagnosis and its remedy, got: %v", err)
 		}
 	})
 

--- a/command/harness/harness.go
+++ b/command/harness/harness.go
@@ -94,6 +94,11 @@ func GetLogoutCmd(writerFn func() Writer) *cobra.Command {
 	return logoutCmd(writerFn)
 }
 
+// GetBenchmarkCmd returns the `pvtr benchmark` command.
+func GetBenchmarkCmd(writerFn func() Writer) *cobra.Command {
+	return benchmarkCmd(writerFn)
+}
+
 // GeneratePlugin forwards to command.GeneratePlugin.
 func GeneratePlugin(logger hclog.Logger) (exitCode int) {
 	return command.GeneratePlugin(logger) //nolint:staticcheck // intentional forwarding during migration

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,9 @@ type Config struct {
 	Policy         Policy
 	Vars           map[string]interface{}
 	Error          error
+
+	Benchmark            bool
+	BenchmarkPayloadOnly bool
 }
 
 // Policy defines the control catalogs and applicability settings for a plugin.
@@ -62,6 +65,8 @@ func NewConfig(requiredVars []string) Config {
 	write := viper.GetBool("write")                                         // defaults to true, but allow the user to disable file writing
 	output := strings.ToLower(strings.TrimSpace(viper.GetString("output"))) // defaults to yaml; can be set to json, sarif, or gemara
 	includePayload := viper.GetBool("include-payload")                      // defaults to false; payload is omitted unless explicitly requested
+	benchmark := viper.GetBool("benchmark")                                 // defaults to false
+	benchmarkPayloadOnly := viper.GetBool("benchmark-payload-only")         // defaults to false; loader only, skip steps
 
 	vars := viper.GetStringMap("vars")
 	localVars := viper.GetStringMap(fmt.Sprintf("services.%s.vars", serviceName))
@@ -140,13 +145,15 @@ func NewConfig(requiredVars []string) Config {
 	}
 
 	config := Config{
-		ServiceName:    serviceName,
-		LogLevel:       loglevel,
-		WriteDirectory: writeDir,
-		Write:          write,
-		Output:         output,
-		IncludePayload: includePayload,
-		Invasive:       invasive,
+		ServiceName:          serviceName,
+		LogLevel:             loglevel,
+		WriteDirectory:       writeDir,
+		Write:                write,
+		Output:               output,
+		IncludePayload:       includePayload,
+		Invasive:             invasive,
+		Benchmark:            benchmark,
+		BenchmarkPayloadOnly: benchmarkPayloadOnly,
 		Policy: Policy{
 			ControlCatalogs: catalogs,
 			Applicability:   applicability,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,8 @@ on the CLI root.
 | `hub-url` | `--hub-url` | `PVTR_HUB_URL` | `https://hub.grc.store` | Hub base URL. Registry host is discovered from it. |
 | `autoinstall` | `--autoinstall` | `PVTR_AUTOINSTALL` | `false` | Auto-install missing plugins before `pvtr run`. |
 | `binaries-path` | -- | `PVTR_BINARIES_PATH` | -- | Plugin install directory. Config/env only. |
+| `benchmark` | -- | `PVTR_BENCHMARK` | `false` | Time the loader and every step; write `benchmark.json` next to results. Set by `pvtr benchmark`; env only for direct plugin runs. |
+| `benchmark-payload-only` | -- | `PVTR_BENCHMARK_PAYLOAD_ONLY` | `false` | Time the loader only and skip assessment steps. Ignored unless `benchmark` is set. |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -101,7 +101,7 @@ func BearerToken(ctx context.Context, issuer, clientID string) (string, error) {
 		// A failed cache write must not fail the operation — we still hold a valid
 		// token — but it must be VISIBLE: under refresh-token rotation the on-disk
 		// token is now consumed, so the next run will force a re-login.
-		fmt.Fprintf(os.Stderr, "warning: failed to cache refreshed credentials (next run may require `pvtr login`): %v\n", perr)
+		_, _ = fmt.Fprintf(os.Stderr, "warning: failed to cache refreshed credentials (next run may require `pvtr login`): %v\n", perr)
 	}
 	return refreshed.AccessToken, nil
 }

--- a/pluginkit/apicalls.go
+++ b/pluginkit/apicalls.go
@@ -1,0 +1,79 @@
+package pluginkit
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// APICallCounter tallies outbound HTTP requests, letting a plugin's payload
+// satisfy APICallReporter without hand-rolling a RoundTripper. Embed a
+// *APICallCounter in the payload and APICallCount is promoted onto it:
+//
+//	type Payload struct {
+//	    // ...
+//	    *pluginkit.APICallCounter
+//	}
+//
+//	counter := &pluginkit.APICallCounter{}
+//	httpClient := counter.WrapClient(oauth2.NewClient(ctx, src))
+//	return Payload{APICallCounter: counter /* ... */}
+//
+// Embed the pointer, not the value: payloads are commonly used by value, and a
+// value-embedded counter would be copied so the tallies diverge. Copying is a
+// `go vet` copylocks error rather than a silent miscount, because the tally is
+// an atomic.Int64.
+//
+// The tally counts HTTP round trips, which is a close proxy for API calls but
+// not identical: retries and redirects each increment it, while one request
+// batching several logical queries (a GraphQL document, say) counts once. It is
+// a rate-limit budget, not an exact call ledger. All hosts share one tally; a
+// plugin calling two rate-limited services sees their sum.
+//
+// The zero value is ready to use, and a nil *APICallCounter reports zero.
+type APICallCounter struct {
+	n atomic.Int64
+}
+
+// APICallCount implements APICallReporter. It is safe on a nil receiver so a
+// payload built without a counter reports zero rather than panicking.
+func (c *APICallCounter) APICallCount() int {
+	if c == nil {
+		return 0
+	}
+	return int(c.n.Load())
+}
+
+// Wrap returns base decorated to count every round trip through it. A nil base
+// means http.DefaultTransport, matching http.Client's own behavior. A nil
+// counter returns base undecorated.
+func (c *APICallCounter) Wrap(base http.RoundTripper) http.RoundTripper {
+	if c == nil {
+		return base
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &countingTransport{base: base, counter: c}
+}
+
+// WrapClient decorates client's transport in place and returns client, so it
+// composes with a client an auth library already built. A nil client yields a
+// new one.
+func (c *APICallCounter) WrapClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	client.Transport = c.Wrap(client.Transport)
+	return client
+}
+
+// countingTransport increments its counter once per round trip.
+type countingTransport struct {
+	base    http.RoundTripper
+	counter *APICallCounter
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.counter.n.Add(1)
+	return t.base.RoundTrip(req)
+}

--- a/pluginkit/apicalls_test.go
+++ b/pluginkit/apicalls_test.go
@@ -1,0 +1,118 @@
+package pluginkit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestAPICallCounter_NilReportsZero(t *testing.T) {
+	var counter *APICallCounter
+	if got := counter.APICallCount(); got != 0 {
+		t.Errorf("expected a nil counter to report 0, got %d", got)
+	}
+}
+
+func TestAPICallCounter_ZeroValueIsUsable(t *testing.T) {
+	counter := &APICallCounter{}
+	if got := counter.APICallCount(); got != 0 {
+		t.Errorf("expected a fresh counter to report 0, got %d", got)
+	}
+}
+
+func TestAPICallCounter_CountsRoundTrips(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	counter := &APICallCounter{}
+	client := counter.WrapClient(&http.Client{})
+
+	for range 3 {
+		resp, err := client.Get(server.URL)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		resp.Body.Close()
+	}
+
+	if got := counter.APICallCount(); got != 3 {
+		t.Errorf("expected 3 counted round trips, got %d", got)
+	}
+}
+
+// TestAPICallCounter_PayloadPromotesMethod is the documented usage: the payload
+// embeds the counter and satisfies APICallReporter without declaring a method.
+func TestAPICallCounter_PayloadPromotesMethod(t *testing.T) {
+	type payload struct {
+		Repo string
+		*APICallCounter
+	}
+
+	counter := &APICallCounter{}
+	p := payload{Repo: "x", APICallCounter: counter}
+
+	var reporter APICallReporter = p
+	counter.n.Add(7)
+
+	if got := reporter.APICallCount(); got != 7 {
+		t.Errorf("expected the promoted method to report 7, got %d", got)
+	}
+
+	// copying the payload by value must still observe the same tally, which is
+	// the reason the counter is embedded as a pointer
+	clone := p
+	counter.n.Add(1)
+	if got := clone.APICallCount(); got != 8 {
+		t.Errorf("expected a payload copy to share the tally, got %d", got)
+	}
+}
+
+func TestAPICallCounter_WrapPreservesBaseAndDefaults(t *testing.T) {
+	counter := &APICallCounter{}
+
+	if got := counter.Wrap(nil); got == nil {
+		t.Error("expected a nil base to be replaced with the default transport")
+	}
+
+	var nilCounter *APICallCounter
+	base := http.DefaultTransport
+	if got := nilCounter.Wrap(base); got == nil {
+		t.Error("expected a nil counter to return the base transport undecorated")
+	}
+
+	// WrapClient on a nil client must still produce a usable client
+	if client := counter.WrapClient(nil); client == nil || client.Transport == nil {
+		t.Error("expected WrapClient(nil) to yield a usable client")
+	}
+}
+
+func TestAPICallCounter_ConcurrentRoundTrips(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	counter := &APICallCounter{}
+	client := counter.WrapClient(&http.Client{})
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	if got := counter.APICallCount(); got != 50 {
+		t.Errorf("expected 50 counted round trips, got %d", got)
+	}
+}

--- a/pluginkit/apicalls_test.go
+++ b/pluginkit/apicalls_test.go
@@ -35,7 +35,7 @@ func TestAPICallCounter_CountsRoundTrips(t *testing.T) {
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	if got := counter.APICallCount(); got != 3 {
@@ -107,7 +107,7 @@ func TestAPICallCounter_ConcurrentRoundTrips(t *testing.T) {
 			if err != nil {
 				return
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}()
 	}
 	wg.Wait()

--- a/pluginkit/benchmark.go
+++ b/pluginkit/benchmark.go
@@ -99,7 +99,10 @@ func (v *EvaluationOrchestrator) apiCallsReported() (int, bool) {
 	}
 
 	add(v.Payload)
-	for _, suite := range v.Evaluation_Suites {
+	// possibleSuites, not Evaluation_Suites: loadPayload runs every possible
+	// suite's loader, and payload-only mode leaves Evaluation_Suites empty.
+	// The loader guard skips suites sharing v.Payload, so nothing double-counts.
+	for _, suite := range v.possibleSuites {
 		if suite.loader != nil {
 			add(suite.payload)
 		}

--- a/pluginkit/benchmark.go
+++ b/pluginkit/benchmark.go
@@ -1,0 +1,146 @@
+package pluginkit
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"reflect"
+	"runtime"
+	"time"
+
+	"github.com/privateerproj/privateer-sdk/utils"
+)
+
+// BenchmarkFileName is the report's fixed name, written into
+// <write-directory>/<service>/ and located by the harness after a run.
+const BenchmarkFileName = "benchmark.json"
+
+// BenchmarkSchema identifies the benchmark report format for machine consumers.
+const BenchmarkSchema = "privateer-benchmark/v1"
+
+// APICallReporter is an optional interface a plugin may implement to
+// report its cumulative external API-call count.
+type APICallReporter interface {
+	APICallCount() int
+}
+
+type BenchmarkReport struct {
+	Schema        string `json:"schema" yaml:"schema"`
+	PluginName    string `json:"plugin-name" yaml:"plugin-name"`
+	PluginVersion string `json:"plugin-version" yaml:"plugin-version"`
+	ServiceName   string `json:"service-name" yaml:"service-name"`
+
+	Loaders         []LoaderTiming `json:"loaders" yaml:"loaders"`
+	Suites          []SuiteTiming  `json:"suites" yaml:"suites"`
+	TotalDurationNs int64          `json:"total-duration-ns" yaml:"total-duration-ns"`
+	APICalls        *int           `json:"api-calls,omitempty" yaml:"api-calls,omitempty"`
+	WallClockNs     int64          `json:"wall-clock-ns,omitempty" yaml:"wall-clock-ns,omitempty"`
+}
+
+// LoaderTiming times one DataLoader invocation.
+type LoaderTiming struct {
+	// Scope is "orchestrator" or "suite:<catalog-id>".
+	Scope      string `json:"scope" yaml:"scope"`
+	Func       string `json:"func" yaml:"func"`
+	DurationNs int64  `json:"duration-ns" yaml:"duration-ns"`
+}
+
+// SuiteTiming times one evaluation suite and its executed steps.
+type SuiteTiming struct {
+	CatalogId  string       `json:"catalog-id" yaml:"catalog-id"`
+	DurationNs int64        `json:"duration-ns" yaml:"duration-ns"`
+	Steps      []StepTiming `json:"steps" yaml:"steps"`
+}
+
+// StepTiming times one executed assessment step; steps that never ran produce no entry.
+type StepTiming struct {
+	ControlId     string `json:"control-id" yaml:"control-id"`
+	RequirementId string `json:"requirement-id" yaml:"requirement-id"`
+	StepIndex     int    `json:"step-index" yaml:"step-index"`
+	Step          string `json:"step" yaml:"step"`
+	Result        string `json:"result" yaml:"result"`
+	DurationNs    int64  `json:"duration-ns" yaml:"duration-ns"`
+}
+
+// funcName resolves a function value's symbol name, as gemara names steps.
+func funcName(fn any) string {
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func || v.IsNil() {
+		return "<unknown function>"
+	}
+	f := runtime.FuncForPC(v.Pointer())
+	if f == nil {
+		return "<unknown function>"
+	}
+	return f.Name()
+}
+
+// recordLoader appends a loader timing when benchmark mode is active.
+func (v *EvaluationOrchestrator) recordLoader(scope string, loader DataLoader, d time.Duration) {
+	if v.benchmark == nil {
+		return
+	}
+	v.benchmark.Loaders = append(v.benchmark.Loaders, LoaderTiming{
+		Scope:      scope,
+		Func:       funcName(loader),
+		DurationNs: d.Nanoseconds(),
+	})
+}
+
+// apiCallsReported sums the APICallReporter counts, false when none report.
+func (v *EvaluationOrchestrator) apiCallsReported() (int, bool) {
+	var total int
+	var found bool
+	add := func(payload any) {
+		if reporter, ok := payload.(APICallReporter); ok {
+			total += reporter.APICallCount()
+			found = true
+		}
+	}
+
+	add(v.Payload)
+	for _, suite := range v.Evaluation_Suites {
+		if suite.loader != nil {
+			add(suite.payload)
+		}
+	}
+	return total, found
+}
+
+// finalizeBenchmark completes and writes the report to
+// <write-directory>/<service>/benchmark.json
+// ignores --write=false
+func (v *EvaluationOrchestrator) finalizeBenchmark(start time.Time) {
+	if v.benchmark == nil {
+		return
+	}
+	v.benchmark.ServiceName = v.ServiceName
+	for _, suite := range v.Evaluation_Suites {
+		v.benchmark.Suites = append(v.benchmark.Suites, SuiteTiming{
+			CatalogId:  suite.CatalogId,
+			DurationNs: suite.durationNs,
+			Steps:      suite.stepTimings,
+		})
+	}
+
+	// This makes an unreported value nil instead of zero
+	if calls, ok := v.apiCallsReported(); ok {
+		v.benchmark.APICalls = &calls
+	}
+	v.benchmark.TotalDurationNs = time.Since(start).Nanoseconds()
+
+	data, err := json.MarshalIndent(v.benchmark, "", "  ")
+	if err != nil {
+		v.config.Logger.Warn("failed to marshal benchmark report", "error", err)
+		return
+	}
+	dir := path.Join(v.config.WriteDirectory, v.ServiceName)
+	if err := os.MkdirAll(dir, utils.DirPermissions); err != nil {
+		v.config.Logger.Warn("failed to create benchmark report directory", "directory", dir, "error", err)
+		return
+	}
+	filepath := path.Join(dir, BenchmarkFileName)
+	if err := os.WriteFile(filepath, data, 0o640); err != nil {
+		v.config.Logger.Warn("failed to write benchmark report", "filepath", filepath, "error", err)
+	}
+}

--- a/pluginkit/benchmark.go
+++ b/pluginkit/benchmark.go
@@ -2,6 +2,7 @@ package pluginkit
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"reflect"
@@ -113,9 +114,9 @@ func (v *EvaluationOrchestrator) apiCallsReported() (int, bool) {
 // finalizeBenchmark completes and writes the report to
 // <write-directory>/<service>/benchmark.json
 // ignores --write=false
-func (v *EvaluationOrchestrator) finalizeBenchmark(start time.Time) {
+func (v *EvaluationOrchestrator) finalizeBenchmark(start time.Time) error {
 	if v.benchmark == nil {
-		return
+		return nil
 	}
 	v.benchmark.ServiceName = v.ServiceName
 	for _, suite := range v.Evaluation_Suites {
@@ -134,16 +135,15 @@ func (v *EvaluationOrchestrator) finalizeBenchmark(start time.Time) {
 
 	data, err := json.MarshalIndent(v.benchmark, "", "  ")
 	if err != nil {
-		v.config.Logger.Warn("failed to marshal benchmark report", "error", err)
-		return
+		return BENCHMARK_WRITE_FAILED(err, "fb10")
 	}
 	dir := path.Join(v.config.WriteDirectory, v.ServiceName)
 	if err := os.MkdirAll(dir, utils.DirPermissions); err != nil {
-		v.config.Logger.Warn("failed to create benchmark report directory", "directory", dir, "error", err)
-		return
+		return BENCHMARK_WRITE_FAILED(fmt.Errorf("creating %s: %w", dir, err), "fb20")
 	}
 	filepath := path.Join(dir, BenchmarkFileName)
 	if err := os.WriteFile(filepath, data, 0o640); err != nil {
-		v.config.Logger.Warn("failed to write benchmark report", "filepath", filepath, "error", err)
+		return BENCHMARK_WRITE_FAILED(fmt.Errorf("writing %s: %w", filepath, err), "fb30")
 	}
+	return nil
 }

--- a/pluginkit/benchmark_test.go
+++ b/pluginkit/benchmark_test.go
@@ -2,6 +2,7 @@ package pluginkit
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/gemaraproj/go-gemara"
 
 	"github.com/privateerproj/privateer-sdk/config"
+	"github.com/privateerproj/privateer-sdk/shared"
 )
 
 // countingPayload implements APICallReporter for benchmark tests.
@@ -434,5 +436,43 @@ func TestBenchmark_PayloadOnly_ReportsPerSuiteAPICalls(t *testing.T) {
 	}
 	if *report.APICalls != 7 {
 		t.Errorf("expected 7 API calls, got %d", *report.APICalls)
+	}
+}
+
+// A benchmark report that cannot be written must fail the run rather than be
+// swallowed: the plugin's log lands in a file the harness never reads, so a
+// silent failure leaves the harness guessing why the report is missing.
+func TestBenchmark_UnwritableReport_FailsMobilize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Occupy the report's directory path with a regular file so MkdirAll fails.
+	blocker := path.Join(tmpDir, "test-service")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o640); err != nil {
+		t.Fatalf("seeding blocker: %v", err)
+	}
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false // isolate the benchmark write from result writing
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+
+	orchestrator := benchmarkOrchestrator(cfg, map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {step_Pass},
+	})
+
+	err := orchestrator.Mobilize()
+	if err == nil {
+		t.Fatal("expected Mobilize to fail when the benchmark report cannot be written")
+	}
+	if !strings.Contains(err.Error(), "failed to write benchmark report") {
+		t.Errorf("expected a benchmark-write diagnosis, got: %v", err)
+	}
+	// ErrRuntime, not ErrDevBug: a full disk is not plugin misuse.
+	if !errors.Is(err, ErrRuntime) {
+		t.Errorf("expected ErrRuntime so ExitCodeFor yields InternalError, got: %v", err)
+	}
+	if code := ExitCodeFor(orchestrator, err); code != shared.InternalError {
+		t.Errorf("expected InternalError so the harness reports the real cause, got %d", code)
 	}
 }

--- a/pluginkit/benchmark_test.go
+++ b/pluginkit/benchmark_test.go
@@ -1,0 +1,386 @@
+package pluginkit
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gemaraproj/go-gemara"
+
+	"github.com/privateerproj/privateer-sdk/config"
+)
+
+// countingPayload implements APICallReporter for benchmark tests.
+type countingPayload struct {
+	calls int
+}
+
+func (p *countingPayload) APICallCount() int { return p.calls }
+
+func slowLoader(_ *config.Config) (any, error) {
+	time.Sleep(2 * time.Millisecond)
+	return &countingPayload{calls: 7}, nil
+}
+
+func step_Slow(_ interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+	time.Sleep(5 * time.Millisecond)
+	return gemara.Passed, "This step is slow but passes", gemara.High
+}
+
+// benchmarkOrchestrator builds a manually-constructed orchestrator matching the
+// Mobilize test pattern, with benchmark mode toggled by the caller.
+func benchmarkOrchestrator(cfg *config.Config, steps map[string][]gemara.AssessmentStep) *EvaluationOrchestrator {
+	catalog := getTestCatalogWithRequirements()
+	return &EvaluationOrchestrator{
+		ServiceName: "test-service",
+		PluginName:  "test-plugin",
+		config:      cfg,
+		loader:      slowLoader,
+		possibleSuites: []*EvaluationSuite{
+			{CatalogId: "CCC.ObjStor", catalog: catalog, steps: steps, config: cfg},
+		},
+	}
+}
+
+func TestBenchmark_Mobilize_WritesReport(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false // the report must be written even when results are not
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+
+	steps := map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {step_Pass, step_Slow},
+	}
+	orchestrator := benchmarkOrchestrator(cfg, steps)
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	reportPath := path.Join(tmpDir, "test-service", BenchmarkFileName)
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("expected benchmark report at %s: %v", reportPath, err)
+	}
+
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+
+	if report.Schema != BenchmarkSchema {
+		t.Errorf("expected schema %q, got %q", BenchmarkSchema, report.Schema)
+	}
+	if report.PluginName != "test-plugin" || report.ServiceName != "test-service" {
+		t.Errorf("expected plugin/service identity, got %q/%q", report.PluginName, report.ServiceName)
+	}
+
+	if len(report.Loaders) != 1 {
+		t.Fatalf("expected 1 loader timing, got %d", len(report.Loaders))
+	}
+	loader := report.Loaders[0]
+	if loader.Scope != "orchestrator" {
+		t.Errorf("expected loader scope 'orchestrator', got %q", loader.Scope)
+	}
+	if loader.DurationNs < (2 * time.Millisecond).Nanoseconds() {
+		t.Errorf("expected loader duration >= 2ms, got %dns", loader.DurationNs)
+	}
+	if !strings.Contains(loader.Func, "slowLoader") {
+		t.Errorf("expected loader func name to contain 'slowLoader', got %q", loader.Func)
+	}
+
+	if len(report.Suites) != 1 {
+		t.Fatalf("expected 1 suite timing, got %d", len(report.Suites))
+	}
+	suite := report.Suites[0]
+	if suite.CatalogId != "CCC.ObjStor" {
+		t.Errorf("expected suite catalog CCC.ObjStor, got %q", suite.CatalogId)
+	}
+	if suite.DurationNs <= 0 {
+		t.Errorf("expected positive suite duration, got %dns", suite.DurationNs)
+	}
+	if len(suite.Steps) != 2 {
+		t.Fatalf("expected 2 executed step timings, got %d", len(suite.Steps))
+	}
+	for _, st := range suite.Steps {
+		if st.ControlId != "CCC.Core.C01" || st.RequirementId != "CCC.Core.C01.TR01" {
+			t.Errorf("step timing misattributed: %+v", st)
+		}
+		if st.Result != "Passed" {
+			t.Errorf("expected step result Passed, got %q", st.Result)
+		}
+		if st.DurationNs <= 0 {
+			t.Errorf("expected positive step duration, got %dns", st.DurationNs)
+		}
+	}
+	if !strings.Contains(suite.Steps[0].Step, "step_Pass") || !strings.Contains(suite.Steps[1].Step, "step_Slow") {
+		t.Errorf("expected original step names to be preserved, got %q, %q", suite.Steps[0].Step, suite.Steps[1].Step)
+	}
+	// The 5ms sleeper must read as such at sub-ms resolution — the whole point
+	// of monotonic durations over the second-resolution timestamps they replace.
+	if suite.Steps[1].DurationNs < (5 * time.Millisecond).Nanoseconds() {
+		t.Errorf("expected slow step >= 5ms, got %dns", suite.Steps[1].DurationNs)
+	}
+
+	if report.APICalls == nil || *report.APICalls != 7 {
+		t.Errorf("expected api-calls 7 from APICallReporter payload, got %v", report.APICalls)
+	}
+	if report.TotalDurationNs < loader.DurationNs {
+		t.Errorf("expected total (%dns) >= loader (%dns)", report.TotalDurationNs, loader.DurationNs)
+	}
+
+	// StartTime must now be parseable, high-resolution RFC3339.
+	if _, err := time.Parse(time.RFC3339Nano, orchestrator.Evaluation_Suites[0].StartTime); err != nil {
+		t.Errorf("suite StartTime is not RFC3339Nano: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, orchestrator.Evaluation_Suites[0].EndTime); err != nil {
+		t.Errorf("suite EndTime is not RFC3339Nano: %v", err)
+	}
+}
+
+// Payload-only mode times the loader and stops: the assessment steps must not
+// run, and the report must carry the loader timing but no suites.
+func TestBenchmark_PayloadOnly_SkipsAssessment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+	cfg.BenchmarkPayloadOnly = true
+
+	stepRan := false
+	sentinel := func(_ interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+		stepRan = true
+		return gemara.Passed, "should never run in payload-only mode", gemara.High
+	}
+	steps := map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {sentinel},
+	}
+	orchestrator := benchmarkOrchestrator(cfg, steps)
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+	if stepRan {
+		t.Error("assessment step ran in payload-only mode; it must be skipped")
+	}
+	if len(orchestrator.Evaluation_Suites) != 0 {
+		t.Errorf("expected no evaluated suites in payload-only mode, got %d", len(orchestrator.Evaluation_Suites))
+	}
+
+	reportPath := path.Join(tmpDir, "test-service", BenchmarkFileName)
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("expected benchmark report at %s: %v", reportPath, err)
+	}
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+	if len(report.Loaders) != 1 {
+		t.Fatalf("expected the loader to still be timed, got %d loader timings", len(report.Loaders))
+	}
+	if len(report.Suites) != 0 {
+		t.Errorf("expected no suite timings in payload-only mode, got %d", len(report.Suites))
+	}
+}
+
+// Payload-only is inert without benchmark mode: a stray env var must never make
+// a normal run skip its assessments.
+func TestBenchmark_PayloadOnly_IgnoredWhenBenchmarkOff(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = false
+	cfg.BenchmarkPayloadOnly = true
+
+	stepRan := false
+	sentinel := func(_ interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+		stepRan = true
+		return gemara.Passed, "runs because benchmark is off", gemara.High
+	}
+	steps := map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {sentinel},
+	}
+	orchestrator := benchmarkOrchestrator(cfg, steps)
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+	if !stepRan {
+		t.Error("assessment step was skipped even though benchmark mode is off")
+	}
+}
+
+// A benchmark run also writes a normal results document. The step wrapping
+// must not leak into it: gemara names steps by runtime symbol, and every
+// timing closure shares one symbol, so unrestored wrapping would collapse
+// every assessment's steps to the same meaningless name.
+func TestBenchmark_ResultsDocumentKeepsRealStepNames(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = true
+	cfg.WriteDirectory = tmpDir
+	cfg.Output = "json"
+	cfg.Benchmark = true
+
+	steps := map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {step_Pass, step_Slow},
+	}
+	orchestrator := benchmarkOrchestrator(cfg, steps)
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	// Assert on the in-memory log and the written document: the written file is
+	// what a plugin author (and any downstream consumer) actually reads.
+	assessment := orchestrator.Evaluation_Suites[0].EvaluationLog.Evaluations[0].AssessmentLogs[0]
+	if len(assessment.Steps) != 2 {
+		t.Fatalf("expected 2 steps restored, got %d", len(assessment.Steps))
+	}
+	first, second := assessment.Steps[0].String(), assessment.Steps[1].String()
+	if !strings.Contains(first, "step_Pass") || !strings.Contains(second, "step_Slow") {
+		t.Errorf("expected the plugin's own step names, got %q and %q", first, second)
+	}
+	if first == second {
+		t.Errorf("distinct steps collapsed to one name: %q", first)
+	}
+
+	written, err := os.ReadFile(path.Join(tmpDir, "test-service", "test-service.json"))
+	if err != nil {
+		t.Fatalf("reading written results: %v", err)
+	}
+	if strings.Contains(string(written), "timedSteps") {
+		t.Error("benchmark timing closure leaked into the written results document")
+	}
+}
+
+// The api-calls hook must work for suites that load their own payload, not
+// only the shared orchestrator payload — per-suite loaders are a supported
+// configuration and are just as likely to be API-bound.
+func TestBenchmark_APICallReporter_SuiteLoader(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+
+	catalog := getTestCatalogWithRequirements()
+	orchestrator := &EvaluationOrchestrator{
+		ServiceName: "test-service",
+		PluginName:  "test-plugin",
+		config:      cfg,
+		// No orchestrator-level loader: the suite loads its own payload.
+		possibleSuites: []*EvaluationSuite{
+			{
+				CatalogId: "CCC.ObjStor",
+				catalog:   catalog,
+				steps:     createPassingStepsMap(),
+				config:    cfg,
+				loader:    func(_ *config.Config) (any, error) { return &countingPayload{calls: 13}, nil },
+			},
+		},
+	}
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path.Join(tmpDir, "test-service", BenchmarkFileName))
+	if err != nil {
+		t.Fatalf("expected benchmark report: %v", err)
+	}
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+
+	if len(report.Loaders) != 1 || report.Loaders[0].Scope != "suite:CCC.ObjStor" {
+		t.Errorf("expected one suite-scoped loader timing, got %+v", report.Loaders)
+	}
+	if report.APICalls == nil || *report.APICalls != 13 {
+		t.Errorf("expected api-calls 13 from the suite payload, got %v", report.APICalls)
+	}
+}
+
+func TestBenchmark_Disabled_NoReportNoWrapping(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = false
+
+	orchestrator := benchmarkOrchestrator(cfg, createPassingStepsMap())
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	reportPath := path.Join(tmpDir, "test-service", BenchmarkFileName)
+	if _, err := os.Stat(reportPath); !os.IsNotExist(err) {
+		t.Errorf("expected no benchmark report when benchmark mode is off, stat err: %v", err)
+	}
+
+	suite := orchestrator.Evaluation_Suites[0]
+	if suite.stepTimings != nil {
+		t.Errorf("expected no step timings when benchmark mode is off, got %d", len(suite.stepTimings))
+	}
+	// The serialized step name must be the plugin's own function, not a wrapper:
+	// normal runs must be completely untouched by the instrumentation.
+	stepName := suite.EvaluationLog.Evaluations[0].AssessmentLogs[0].Steps[0].String()
+	if !strings.Contains(stepName, "step_Pass") {
+		t.Errorf("expected unwrapped step name containing 'step_Pass', got %q", stepName)
+	}
+}
+
+func TestBenchmark_FailedStep_RecordsResultAndHalts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+
+	steps := map[string][]gemara.AssessmentStep{
+		"CCC.Core.C01.TR01": {step_Fail, step_Pass}, // halt after the failure
+	}
+	orchestrator := benchmarkOrchestrator(cfg, steps)
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path.Join(tmpDir, "test-service", BenchmarkFileName))
+	if err != nil {
+		t.Fatalf("expected benchmark report: %v", err)
+	}
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+
+	if len(report.Suites) != 1 || len(report.Suites[0].Steps) != 1 {
+		t.Fatalf("expected exactly the executed (failing) step to be timed, got %+v", report.Suites)
+	}
+	st := report.Suites[0].Steps[0]
+	if st.Result != "Failed" || !strings.Contains(st.Step, "step_Fail") {
+		t.Errorf("expected the failing step's timing, got %+v", st)
+	}
+}

--- a/pluginkit/benchmark_test.go
+++ b/pluginkit/benchmark_test.go
@@ -384,3 +384,55 @@ func TestBenchmark_FailedStep_RecordsResultAndHalts(t *testing.T) {
 		t.Errorf("expected the failing step's timing, got %+v", st)
 	}
 }
+
+// Payload-only mode exists to isolate loader cost, so it must still report the
+// API calls of a per-suite loader's payload even though no suite is evaluated.
+func TestBenchmark_PayloadOnly_ReportsPerSuiteAPICalls(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+	cfg.BenchmarkPayloadOnly = true
+
+	catalog := getTestCatalogWithRequirements()
+	orchestrator := &EvaluationOrchestrator{
+		ServiceName: "test-service",
+		PluginName:  "test-plugin",
+		config:      cfg,
+		// no orchestrator loader: the payload comes only from the suite
+		possibleSuites: []*EvaluationSuite{
+			{
+				CatalogId: "CCC.ObjStor",
+				catalog:   catalog,
+				steps:     map[string][]gemara.AssessmentStep{"CCC.Core.C01.TR01": {step_Pass}},
+				config:    cfg,
+				loader: func(*config.Config) (any, error) {
+					return &countingPayload{calls: 7}, nil
+				},
+			},
+		},
+	}
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path.Join(tmpDir, "test-service", BenchmarkFileName))
+	if err != nil {
+		t.Fatalf("expected benchmark report: %v", err)
+	}
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+
+	if report.APICalls == nil {
+		t.Fatalf("expected the per-suite payload's API calls to be reported, got nil")
+	}
+	if *report.APICalls != 7 {
+		t.Errorf("expected 7 API calls, got %d", *report.APICalls)
+	}
+}

--- a/pluginkit/errors.go
+++ b/pluginkit/errors.go
@@ -68,6 +68,9 @@ var (
 	NO_MATCHING_CATALOGS = func(requested []string, available []string, mod string) error {
 		return wrap(ErrDevBug, fmt.Sprintf("no requested catalogs matched available suites. requested=%v available=%v", requested, available), mod)
 	}
+	BENCHMARK_WRITE_FAILED = func(err error, mod string) error {
+		return wrap(ErrRuntime, fmt.Sprintf("failed to write benchmark report: %s", err), mod)
+	}
 )
 
 // wrap chains the category sentinel via %w so errors.Is works, while keeping

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -52,6 +52,7 @@ type EvaluationOrchestrator struct {
 	config            *config.Config
 	loader            DataLoader
 	targetBuilder     TargetBuilder
+	benchmark         *BenchmarkReport
 }
 
 // DataLoader is a function type for loading plugin data from configuration.
@@ -121,7 +122,19 @@ func (v *EvaluationOrchestrator) addPossibleControls(catalog *gemara.ControlCata
 }
 
 // AddEvaluationSuite adds an evaluation suite for the given catalog ID.
+//
+// Steps registered this way are named by symbol lookup at report time, which
+// only resolves while the step is a plain function value. Plugins that adapt
+// their steps through a closure should register via AddEvaluationSuiteTyped so
+// the SDK captures each step's name before it is captured.
 func (v *EvaluationOrchestrator) AddEvaluationSuite(catalogId string, loader DataLoader, steps map[string][]gemara.AssessmentStep) error {
+	return v.addEvaluationSuiteNamed(catalogId, loader, steps, nil)
+}
+
+// addEvaluationSuiteNamed is AddEvaluationSuite with optional step names,
+// supplied by the typed registration helpers. names is keyed by requirement id
+// and positionally parallel to steps; a nil map falls back to symbol lookup.
+func (v *EvaluationOrchestrator) addEvaluationSuiteNamed(catalogId string, loader DataLoader, steps map[string][]gemara.AssessmentStep, names map[string][]string) error {
 	if catalogId == "" {
 		return BAD_CATALOG(v.PluginName, "suite catalog id cannot be empty", "aos10")
 	}
@@ -132,7 +145,7 @@ func (v *EvaluationOrchestrator) AddEvaluationSuite(catalogId string, loader Dat
 		if catalog.Metadata.Id == "" {
 			return BAD_CATALOG(v.PluginName, "no id found in catalog metadata", "aos30")
 		}
-		v.addEvaluationSuite(catalog, loader, steps)
+		v.addEvaluationSuite(catalog, loader, steps, names)
 		return nil
 	}
 	return BAD_CATALOG(v.PluginName, fmt.Sprintf("no reference catalog found with id '%s'", catalogId), "aos40")
@@ -154,7 +167,7 @@ func (v *EvaluationOrchestrator) AddEvaluationSuiteForAllCatalogs(loader DataLoa
 	return nil
 }
 
-func (v *EvaluationOrchestrator) addEvaluationSuite(catalog *gemara.ControlCatalog, loader DataLoader, steps map[string][]gemara.AssessmentStep) {
+func (v *EvaluationOrchestrator) addEvaluationSuite(catalog *gemara.ControlCatalog, loader DataLoader, steps map[string][]gemara.AssessmentStep, names map[string][]string) {
 	for _, existing := range v.possibleSuites {
 		if existing.CatalogId == catalog.Metadata.Id {
 			return
@@ -177,6 +190,7 @@ func (v *EvaluationOrchestrator) addEvaluationSuite(catalog *gemara.ControlCatal
 		CatalogId: catalog.Metadata.Id,
 		catalog:   suiteCatalog,
 		steps:     steps,
+		stepNames: names,
 		config:    v.config,
 	}
 
@@ -224,6 +238,17 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 		return BAD_CONFIG(v.config.Error, "mob20")
 	}
 
+	// Init before loadPayload so retrieval is timed; nil when off.
+	var benchmarkStart time.Time
+	if v.config.Benchmark {
+		benchmarkStart = time.Now()
+		v.benchmark = &BenchmarkReport{
+			Schema:        BenchmarkSchema,
+			PluginName:    v.PluginName,
+			PluginVersion: v.PluginVersion,
+		}
+	}
+
 	err := v.loadPayload()
 	if err != nil {
 		return BAD_LOADER(v.PluginName, err, "mob30")
@@ -233,6 +258,12 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 
 	if v.PluginName == "" || v.ServiceName == "" {
 		return EVALUATION_ORCHESTRATOR_NAMES_NOT_SET(v.ServiceName, v.PluginName, "mob40")
+	}
+
+	if v.config.Benchmark && v.config.BenchmarkPayloadOnly {
+		v.config.Logger.Trace("Payload-only benchmark: skipping assessment")
+		v.finalizeBenchmark(benchmarkStart)
+		return nil
 	}
 
 	v.config.Logger.Trace("Mobilization beginning")
@@ -271,9 +302,13 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 	v.config.Logger.Trace("Mobilization complete")
 
 	if !v.config.Write {
+		v.finalizeBenchmark(benchmarkStart)
 		return nil // Do not write results if the user has blocked it
 	}
-	return v.WriteResults()
+	err = v.WriteResults()
+	// after WriteResults so the total includes result writing
+	v.finalizeBenchmark(benchmarkStart)
+	return err
 }
 
 // stampEvaluationLog populates identity, provenance, and outcome on a suite's
@@ -448,7 +483,9 @@ func (v *EvaluationOrchestrator) writeResultsToFile(serviceName string, result [
 // loadPayload loads the payload data to be referenced in assessments.
 func (v *EvaluationOrchestrator) loadPayload() (err error) {
 	if v.loader != nil {
+		start := time.Now()
 		data, err := v.loader(v.config)
+		v.recordLoader("orchestrator", v.loader, time.Since(start))
 		if err != nil {
 			return err
 		}
@@ -456,7 +493,9 @@ func (v *EvaluationOrchestrator) loadPayload() (err error) {
 	}
 	for _, suite := range v.possibleSuites {
 		if suite.loader != nil {
+			start := time.Now()
 			data, err := suite.loader(v.config)
+			v.recordLoader("suite:"+suite.CatalogId, suite.loader, time.Since(start))
 			if err != nil {
 				return err
 			}

--- a/pluginkit/evaluation_orchestrator.go
+++ b/pluginkit/evaluation_orchestrator.go
@@ -262,8 +262,7 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 
 	if v.config.Benchmark && v.config.BenchmarkPayloadOnly {
 		v.config.Logger.Trace("Payload-only benchmark: skipping assessment")
-		v.finalizeBenchmark(benchmarkStart)
-		return nil
+		return v.finalizeBenchmark(benchmarkStart)
 	}
 
 	v.config.Logger.Trace("Mobilization beginning")
@@ -302,13 +301,15 @@ func (v *EvaluationOrchestrator) Mobilize() error {
 	v.config.Logger.Trace("Mobilization complete")
 
 	if !v.config.Write {
-		v.finalizeBenchmark(benchmarkStart)
-		return nil // Do not write results if the user has blocked it
+		// Do not write results if the user has blocked it
+		return v.finalizeBenchmark(benchmarkStart)
 	}
 	err = v.WriteResults()
-	// after WriteResults so the total includes result writing
-	v.finalizeBenchmark(benchmarkStart)
-	return err
+	benchErr := v.finalizeBenchmark(benchmarkStart) // before exiting, append benchmark results if present
+	if err != nil {
+		return err
+	}
+	return benchErr
 }
 
 // stampEvaluationLog populates identity, provenance, and outcome on a suite's

--- a/pluginkit/evaluation_suite.go
+++ b/pluginkit/evaluation_suite.go
@@ -33,10 +33,14 @@ type EvaluationSuite struct {
 	changeManager *ChangeManager                     // changes is a list of changes made during the evaluation
 	catalog       *gemara.ControlCatalog             // The Catalog this evaluation suite references
 	steps         map[string][]gemara.AssessmentStep // steps is a map of control IDs to their assessment steps
+	stepNames     map[string][]string                // step names captured at registration, parallel to steps; nil falls back to symbol lookup
 
 	evalSuccesses int // successes is the number of successful evaluations
 	evalFailures  int // failures is the number of failed evaluations
 	evalWarnings  int // warnings is the number of evaluations that need review
+
+	durationNs  int64        // benchmark mode only
+	stepTimings []StepTiming // benchmark mode only
 }
 
 // AddChangeManager sets up the change manager for the evaluation suite.
@@ -70,7 +74,12 @@ func (e *EvaluationSuite) Evaluate(serviceName string) error {
 
 	e.Name = fmt.Sprintf("%s_%s", serviceName, e.CatalogId)
 	e.EvaluationLog = evalLog
-	e.StartTime = time.Now().String()
+	started := time.Now()
+	e.StartTime = started.UTC().Format(time.RFC3339Nano)
+	if e.config.Benchmark {
+		// duration from the monotonic clock, never timestamp subtraction
+		defer func() { e.durationNs = time.Since(started).Nanoseconds() }()
+	}
 
 	e.config.Logger.Trace("Starting evaluation", "name", e.Name, "time", e.StartTime)
 
@@ -114,7 +123,9 @@ func (e *EvaluationSuite) Evaluate(serviceName string) error {
 
 	output := fmt.Sprintf("> %s: %v Passed, %v Warnings, %v Failed, %v Possible", e.Name, e.evalSuccesses, e.evalWarnings, e.evalFailures, len(evalLog.Evaluations))
 
-	e.EndTime = time.Now().String()
+	e.restoreSteps()
+
+	e.EndTime = time.Now().UTC().Format(time.RFC3339Nano)
 
 	if e.changeManager != nil {
 		e.changeManager.RevertAll()
@@ -135,6 +146,55 @@ func (e *EvaluationSuite) Evaluate(serviceName string) error {
 		e.config.Logger.Error(output)
 	}
 	return nil
+}
+
+// restoreSteps restores benchmark-wrapped steps back to the original for stack tracing
+func (e *EvaluationSuite) restoreSteps() {
+	if e.config == nil || !e.config.Benchmark {
+		return
+	}
+	for _, evaluation := range e.EvaluationLog.Evaluations {
+		for _, assessment := range evaluation.AssessmentLogs {
+			assessment.Steps = e.steps[assessment.Requirement.EntryId]
+		}
+	}
+}
+
+// stepName returns the name captured at registration for the step at index i of
+// requirementId, falling back to symbol lookup when the plugin registered
+// untyped steps. Symbol lookup is only meaningful when the registered value is
+// the plugin's own function; a plugin-side adapter closure resolves to the
+// adapter, identically for every step it wraps.
+func (e *EvaluationSuite) stepName(requirementId string, i int, step gemara.AssessmentStep) string {
+	if names, ok := e.stepNames[requirementId]; ok && i < len(names) && names[i] != "" {
+		return names[i]
+	}
+	return step.String()
+}
+
+// timedSteps wraps each executed step in a closure that records its duration, name, and result.
+func (e *EvaluationSuite) timedSteps(controlId, requirementId string, steps []gemara.AssessmentStep) []gemara.AssessmentStep {
+	if len(steps) == 0 {
+		return steps
+	}
+	timed := make([]gemara.AssessmentStep, len(steps))
+	for i, step := range steps {
+		name := e.stepName(requirementId, i, step)
+		timed[i] = func(payload interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+			start := time.Now()
+			result, message, confidence := step(payload)
+			e.stepTimings = append(e.stepTimings, StepTiming{
+				ControlId:     controlId,
+				RequirementId: requirementId,
+				StepIndex:     i,
+				Step:          name,
+				Result:        result.String(),
+				DurationNs:    time.Since(start).Nanoseconds(),
+			})
+			return result, message, confidence
+		}
+	}
+	return timed
 }
 
 // singleLine collapses a multi-line assessment message into one line so the
@@ -190,12 +250,18 @@ func (e *EvaluationSuite) setupEvalLog(steps map[string][]gemara.AssessmentStep)
 		}
 
 		for _, requirement := range control.AssessmentRequirements {
+			// benchmark mode times each step; later on restoreSteps will unwrap this before serialization
+			reqSteps := steps[requirement.Id]
+			if e.config != nil && e.config.Benchmark {
+				reqSteps = e.timedSteps(control.Id, requirement.Id, reqSteps)
+			}
+
 			// Use AddAssessment instead of manual struct creation
 			assessment := evaluation.AddAssessment(
 				requirement.Id,            // requirementId
 				control.Objective,         // description
 				requirement.Applicability, // applicability
-				steps[requirement.Id],     // steps
+				reqSteps,                  // steps
 			)
 
 			// Handle case where no steps were found

--- a/pluginkit/typed_steps.go
+++ b/pluginkit/typed_steps.go
@@ -1,0 +1,92 @@
+package pluginkit
+
+import (
+	"fmt"
+
+	"github.com/gemaraproj/go-gemara"
+)
+
+// TypedAssessmentStep is the shape of a payload-typed assessment step: the same
+// contract as gemara.AssessmentStep, but receiving a concrete payload type T
+// instead of an untyped any.
+//
+// The type parameter S on the registration helpers below is constrained to
+// ~TypedAssessmentStep[T] so a plugin may keep its own named step type (e.g.
+// `type TypedStep func(data.Payload) (...)`) and pass its existing step maps
+// unchanged.
+type TypedAssessmentStep[T any] func(T) (gemara.Result, string, gemara.ConfidenceLevel)
+
+// FuncName resolves a function value's symbol name, as gemara names steps.
+// Exported so plugins can record step identity themselves; the typed
+// registration helpers below already do this on the caller's behalf.
+//
+// The name can only be resolved while the function is still a symbol. Once a
+// value has been captured into a closure — as happens when a plugin adapts its
+// own steps to gemara.AssessmentStep — every closure produced by that literal
+// shares one code pointer, and the original name is unrecoverable. That is why
+// the adaptation below lives in the SDK: it is the last point at which the
+// plugin's function is still nameable.
+func FuncName(fn any) string {
+	return funcName(fn)
+}
+
+// adaptTypedSteps converts payload-typed steps into gemara.AssessmentStep,
+// resolving each step's name before the closure captures it. It returns the
+// adapted steps and a parallel map of names keyed by requirement id.
+func adaptTypedSteps[S ~func(T) (gemara.Result, string, gemara.ConfidenceLevel), T any](
+	steps map[string][]S,
+) (map[string][]gemara.AssessmentStep, map[string][]string) {
+	adapted := make(map[string][]gemara.AssessmentStep, len(steps))
+	names := make(map[string][]string, len(steps))
+	for id, list := range steps {
+		for _, step := range list {
+			fn := step // capture per iteration, not the loop variable
+			names[id] = append(names[id], FuncName(fn))
+			adapted[id] = append(adapted[id], func(payload any) (gemara.Result, string, gemara.ConfidenceLevel) {
+				typed, ok := payload.(T)
+				if !ok {
+					var zero T
+					return gemara.Unknown, fmt.Sprintf("expected %T, got %T", zero, payload), 0
+				}
+				return fn(typed)
+			})
+		}
+	}
+	return adapted, names
+}
+
+// AddEvaluationSuiteTyped registers an evaluation suite whose steps take a
+// concrete payload type T rather than an untyped any. The SDK performs the
+// payload type assertion once, so plugins need neither a per-step payload guard
+// nor their own adapter — and because the adaptation happens here, each step's
+// real function name survives into the benchmark report.
+//
+// It is a package-level function rather than a method because Go does not allow
+// type parameters on methods.
+//
+// All steps in one call share the payload type T; register a second suite for a
+// step family that consumes a different payload.
+func AddEvaluationSuiteTyped[S ~func(T) (gemara.Result, string, gemara.ConfidenceLevel), T any](
+	v *EvaluationOrchestrator, catalogId string, loader DataLoader, steps map[string][]S,
+) error {
+	adapted, names := adaptTypedSteps[S, T](steps)
+	return v.addEvaluationSuiteNamed(catalogId, loader, adapted, names)
+}
+
+// AddEvaluationSuiteTypedForAllCatalogs is AddEvaluationSuiteTyped applied to
+// every reference catalog loaded via AddReferenceCatalogs, mirroring
+// AddEvaluationSuiteForAllCatalogs.
+func AddEvaluationSuiteTypedForAllCatalogs[S ~func(T) (gemara.Result, string, gemara.ConfidenceLevel), T any](
+	v *EvaluationOrchestrator, loader DataLoader, steps map[string][]S,
+) error {
+	if len(v.referenceCatalogs) == 0 {
+		return BAD_CATALOG(v.PluginName, "no reference catalogs loaded", "aac10")
+	}
+	adapted, names := adaptTypedSteps[S, T](steps)
+	for catalogId := range v.referenceCatalogs {
+		if err := v.addEvaluationSuiteNamed(catalogId, loader, adapted, names); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pluginkit/typed_steps_test.go
+++ b/pluginkit/typed_steps_test.go
@@ -1,0 +1,153 @@
+package pluginkit
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/privateerproj/privateer-sdk/config"
+)
+
+// testPayload stands in for a plugin's concrete payload type.
+type testPayload struct {
+	Repo string
+}
+
+// pluginTypedStep mirrors a plugin's own named step type (e.g. the scanner's
+// evaluation_plans.TypedStep), to prove the ~ constraint accepts it.
+type pluginTypedStep func(testPayload) (gemara.Result, string, gemara.ConfidenceLevel)
+
+func typedStep_BranchProtection(testPayload) (gemara.Result, string, gemara.ConfidenceLevel) {
+	return gemara.Passed, "branch protection ok", gemara.High
+}
+
+func typedStep_SigningEnabled(testPayload) (gemara.Result, string, gemara.ConfidenceLevel) {
+	return gemara.Passed, "signing ok", gemara.High
+}
+
+// pluginAdapter reproduces the closure adapter that destroys step identity, so
+// the test asserts against the exact regression being fixed.
+func (s pluginTypedStep) pluginAdapter() gemara.AssessmentStep {
+	return func(p any) (gemara.Result, string, gemara.ConfidenceLevel) {
+		payload, ok := p.(testPayload)
+		if !ok {
+			return gemara.Unknown, "wrong payload", 0
+		}
+		return s(payload)
+	}
+}
+
+// TestPluginSideAdapterCollapsesStepIdentity documents why the SDK must own the
+// adaptation: a plugin-side adapter yields one symbol for every step.
+func TestPluginSideAdapterCollapsesStepIdentity(t *testing.T) {
+	steps := []pluginTypedStep{typedStep_BranchProtection, typedStep_SigningEnabled}
+
+	names := map[string]bool{}
+	for _, s := range steps {
+		names[FuncName(s.pluginAdapter())] = true
+	}
+	if len(names) != 1 {
+		t.Fatalf("expected the adapter to collapse both steps to one symbol, got %d: %v", len(names), names)
+	}
+
+	// the same values, named before capture, stay distinct
+	direct := map[string]bool{}
+	for _, s := range steps {
+		direct[FuncName(s)] = true
+	}
+	if len(direct) != 2 {
+		t.Errorf("expected 2 distinct names when resolved before capture, got %d: %v", len(direct), direct)
+	}
+}
+
+func TestAdaptTypedSteps_CapturesRealNames(t *testing.T) {
+	steps := map[string][]pluginTypedStep{
+		"CCC.Core.C01.TR01": {typedStep_BranchProtection, typedStep_SigningEnabled},
+	}
+
+	adapted, names := adaptTypedSteps[pluginTypedStep, testPayload](steps)
+
+	got := names["CCC.Core.C01.TR01"]
+	if len(got) != 2 {
+		t.Fatalf("expected 2 captured names, got %d", len(got))
+	}
+	if !strings.HasSuffix(got[0], "typedStep_BranchProtection") {
+		t.Errorf("expected first name to be the real function, got %q", got[0])
+	}
+	if !strings.HasSuffix(got[1], "typedStep_SigningEnabled") {
+		t.Errorf("expected second name to be the real function, got %q", got[1])
+	}
+
+	// the adapted step still runs, with the payload asserted for the caller
+	result, message, _ := adapted["CCC.Core.C01.TR01"][0](testPayload{Repo: "x"})
+	if result != gemara.Passed {
+		t.Errorf("expected adapted step to pass, got %v (%s)", result, message)
+	}
+}
+
+func TestAdaptTypedSteps_PayloadMismatch(t *testing.T) {
+	steps := map[string][]pluginTypedStep{
+		"CCC.Core.C01.TR01": {typedStep_BranchProtection},
+	}
+	adapted, _ := adaptTypedSteps[pluginTypedStep, testPayload](steps)
+
+	result, message, _ := adapted["CCC.Core.C01.TR01"][0]("not-a-payload")
+	if result != gemara.Unknown {
+		t.Errorf("expected Unknown on payload mismatch, got %v", result)
+	}
+	if !strings.Contains(message, "expected pluginkit.testPayload, got string") {
+		t.Errorf("expected a type-mismatch message naming both types, got %q", message)
+	}
+}
+
+// TestBenchmark_TypedSteps_ReportsRealNames is the end-to-end assertion: a
+// benchmark run of typed steps names each step by its own function.
+func TestBenchmark_TypedSteps_ReportsRealNames(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := setBasicConfig()
+	cfg.Policy.ControlCatalogs = []string{"CCC.ObjStor"}
+	cfg.Write = false
+	cfg.WriteDirectory = tmpDir
+	cfg.Benchmark = true
+
+	typed := map[string][]pluginTypedStep{
+		"CCC.Core.C01.TR01": {typedStep_BranchProtection, typedStep_SigningEnabled},
+	}
+	adapted, names := adaptTypedSteps[pluginTypedStep, testPayload](typed)
+
+	orchestrator := benchmarkOrchestrator(cfg, adapted)
+	orchestrator.loader = func(*config.Config) (any, error) { return testPayload{Repo: "x"}, nil }
+	orchestrator.possibleSuites[0].stepNames = names
+
+	if err := orchestrator.Mobilize(); err != nil {
+		t.Fatalf("Mobilize failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path.Join(tmpDir, "test-service", BenchmarkFileName))
+	if err != nil {
+		t.Fatalf("expected benchmark report: %v", err)
+	}
+	var report BenchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("benchmark report is not valid JSON: %v", err)
+	}
+
+	var reported []string
+	for _, suite := range report.Suites {
+		for _, step := range suite.Steps {
+			reported = append(reported, step.Step)
+		}
+	}
+	if len(reported) != 2 {
+		t.Fatalf("expected 2 step timings, got %d: %v", len(reported), reported)
+	}
+	for i, want := range []string{"typedStep_BranchProtection", "typedStep_SigningEnabled"} {
+		if !strings.HasSuffix(reported[i], want) {
+			t.Errorf("step %d: expected name ending %q, got %q", i, want, reported[i])
+		}
+	}
+}


### PR DESCRIPTION
This adds benchmarking for steps and payload retrieval.

I strongly considered not implementing this change, because we could do some of this work with virtually no code at all, because Gemara provides the capability to benchmark assessments (groups of steps). But I felt that was insufficient for grounded decision-making.

This additionally resolves a pre-existing bug that was introduced by wrapping the payload in a typecast step — the function addresses were being swallowed. With this change, the typecasting happens here in the SDK instead of within the plugin, and we are able to capture the step function addresses again.

Here's the implementation from a plugin developer's perspective:
https://github.com/ossf/pvtr-github-repo-scanner/pull/372/changes