### PR TITLE
fix(config): compute default write path once per process

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -205,15 +206,18 @@ func sanitizeVars(vars map[string]interface{}) map[string]interface{} {
 	return sanitizedVars
 }
 
-func defaultWritePath() string {
+// defaultWritePath returns the default write directory, computed once per
+// process so that every config created during a run shares the same
+// timestamped log directory.
+var defaultWritePath = sync.OnceValue(func() string {
 	home, err := os.UserHomeDir()
-	datetime := time.Now().Local().Format(time.RFC3339)
-	dirName := strings.ReplaceAll(datetime, ":", "")
 	if err != nil {
 		return ""
 	}
+	datetime := time.Now().Local().Format(time.RFC3339)
+	dirName := strings.ReplaceAll(datetime, ":", "")
 	return filepath.Join(home, ".privateer", "logs", dirName)
-}
+})
 
 // SetupLogging configures logging for the plugin with the given name and format.
 func (c *Config) SetupLogging(name string, jsonFormat bool) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -575,6 +575,10 @@ func TestDefaultWritePath(t *testing.T) {
 	if !strings.Contains(path, "logs") {
 		t.Error("expected path to contain 'logs'")
 	}
+
+	if again := defaultWritePath(); again != path {
+		t.Errorf("expected defaultWritePath to be stable within a process, got '%s' then '%s'", path, again)
+	}
 }
 
 func TestPrintSanitizedVars(t *testing.T) {


### PR DESCRIPTION
## What/Why

`defaultWritePath()` embedded `time.Now()` at second precision and was called both by `NewConfig` and by test assertions, so any pair of calls straddling a second boundary produced different paths. This made `TestNewConfig` flaky in CI (example: the failed run on #269) and meant multiple configs in one process could log to different directories. The path is now memoized with `sync.OnceValue` so it is stable for the life of the process.

## Proof it works

`go test ./...` passes. Added an assertion in `TestDefaultWritePath` that two calls return the same path, which fails against the old implementation when calls straddle a second boundary.

## Risk + AI role

Low. Behavior change is limited to reusing one timestamped directory per process instead of one per `NewConfig` call. AI-generated, human-reviewed.

## Review focus

Whether a single shared log directory per process is the intended behavior for long-running processes that construct multiple configs.