### PR TITLE
feat: add target/targets aliases for service/services

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/privateerproj/privateer-sdk/config"
 )
 
 // SetBase sets the flags that are universal to every command. These are safe to
@@ -40,6 +42,10 @@ func SetRunFlags(cmd *cobra.Command) {
 	// No shorthand: -t belongs to --test-suites.
 	cmd.PersistentFlags().String("target", "", "Named target to execute from the config (takes precedence over --service)")
 	_ = viper.BindPFlag("target", cmd.PersistentFlags().Lookup("target"))
+
+	// Let config.TargetName rank explicitly passed --target/--service flags
+	// above env and config values; viper can't compare across the two keys.
+	config.BindTargetFlags(cmd.PersistentFlags())
 
 	cmd.PersistentFlags().StringP("test-suites", "t", "default", "Named set of test sets to execute from the plugin")
 	_ = viper.BindPFlag("test-suites", cmd.PersistentFlags().Lookup("test-suites"))

--- a/command/base.go
+++ b/command/base.go
@@ -40,7 +40,7 @@ func SetRunFlags(cmd *cobra.Command) {
 	_ = viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
 
 	// No shorthand: -t belongs to --test-suites.
-	cmd.PersistentFlags().String("target", "", "Named target to execute from the config (takes precedence over --service)")
+	cmd.PersistentFlags().String("target", "", "Named target to execute from the config")
 	_ = viper.BindPFlag("target", cmd.PersistentFlags().Lookup("target"))
 
 	// Let config.TargetName rank explicitly passed --target/--service flags

--- a/command/base.go
+++ b/command/base.go
@@ -34,8 +34,12 @@ func SetRunFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("write-directory", "w", "evaluation_results", "Directory to write evaluation results to")
 	_ = viper.BindPFlag("write-directory", cmd.PersistentFlags().Lookup("write-directory"))
 
-	cmd.PersistentFlags().StringP("service", "s", "", "Named service to execute from the config")
+	cmd.PersistentFlags().StringP("service", "s", "", "Named service to execute from the config (alias for --target)")
 	_ = viper.BindPFlag("service", cmd.PersistentFlags().Lookup("service"))
+
+	// No shorthand: -t belongs to --test-suites.
+	cmd.PersistentFlags().String("target", "", "Named target to execute from the config (takes precedence over --service)")
+	_ = viper.BindPFlag("target", cmd.PersistentFlags().Lookup("target"))
 
 	cmd.PersistentFlags().StringP("test-suites", "t", "default", "Named set of test sets to execute from the plugin")
 	_ = viper.BindPFlag("test-suites", cmd.PersistentFlags().Lookup("test-suites"))

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/privateerproj/privateer-sdk/config"
 )
 
 func resetViper() {
@@ -41,6 +44,10 @@ func TestSetBase_ConfigFlagDefaultIsEmpty(t *testing.T) {
 
 func TestSetRunFlags_TargetAliasForService(t *testing.T) {
 	resetViper()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.BindTargetFlags(nil)
+	})
 	cmd := &cobra.Command{Use: "test"}
 	SetRunFlags(cmd)
 
@@ -64,6 +71,31 @@ func TestSetRunFlags_TargetAliasForService(t *testing.T) {
 	}
 	if got := viper.GetString("target"); got != "my-target" {
 		t.Errorf("viper target binding: got = %q, want = %q", got, "my-target")
+	}
+}
+
+// The harness launches each plugin subprocess with --service=<name> while the
+// child inherits the parent's environment. An inherited PVTR_TARGET must not
+// beat the explicitly passed flag, or every plugin in a multi-target run would
+// resolve the same target and overwrite its results.
+func TestSetRunFlags_ServiceFlagBeatsInheritedEnvTarget(t *testing.T) {
+	resetViper()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.BindTargetFlags(nil)
+	})
+	viper.SetEnvPrefix("PVTR")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+
+	cmd := &cobra.Command{Use: "test"}
+	SetRunFlags(cmd)
+	t.Setenv("PVTR_TARGET", "env-target")
+	if err := cmd.PersistentFlags().Set("service", "flag-service"); err != nil {
+		t.Fatal(err)
+	}
+	if got := config.TargetName(); got != "flag-service" {
+		t.Errorf("config.TargetName() = %q, want = %q", got, "flag-service")
 	}
 }
 

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -39,6 +39,34 @@ func TestSetBase_ConfigFlagDefaultIsEmpty(t *testing.T) {
 	}
 }
 
+func TestSetRunFlags_TargetAliasForService(t *testing.T) {
+	resetViper()
+	cmd := &cobra.Command{Use: "test"}
+	SetRunFlags(cmd)
+
+	target := cmd.PersistentFlags().Lookup("target")
+	if target == nil {
+		t.Fatal("expected target flag to be registered")
+	}
+	if target.Shorthand != "" {
+		t.Errorf("target flag shorthand: got = %q, want none (-t belongs to --test-suites)", target.Shorthand)
+	}
+
+	service := cmd.PersistentFlags().Lookup("service")
+	if service == nil {
+		t.Fatal("expected service flag to remain registered")
+	} else if service.Shorthand != "s" {
+		t.Errorf("service flag shorthand: got = %q, want = %q", service.Shorthand, "s")
+	}
+
+	if err := cmd.PersistentFlags().Set("target", "my-target"); err != nil {
+		t.Fatalf("failed to set target flag: %v", err)
+	}
+	if got := viper.GetString("target"); got != "my-target" {
+		t.Errorf("viper target binding: got = %q, want = %q", got, "my-target")
+	}
+}
+
 func TestReadConfig_ExplicitConfigPath(t *testing.T) {
 	resetViper()
 

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -92,7 +92,7 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 		},
 	}
 	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (alias for --target)")
-	benchmarkCmd.Flags().StringVar(&target, "target", "", "Named target from the config to evaluate (required; wins over --service)")
+	benchmarkCmd.Flags().StringVar(&target, "target", "", "Named target from the config to evaluate (required)")
 	benchmarkCmd.Flags().BoolVar(&jsonOut, "json", false, "Emit the machine-readable benchmark report as JSON (for diffing runs in CI)")
 	benchmarkCmd.Flags().StringVarP(&writeDir, "write-directory", "w", "", "Directory for the run's results and report (default: a temp directory)")
 	benchmarkCmd.Flags().BoolVar(&payloadOnly, "payload-only", false, "Stop after payload retrieval and time only the loader (skip assessment steps)")

--- a/command/harness/benchmark.go
+++ b/command/harness/benchmark.go
@@ -33,6 +33,7 @@ type benchmarkRow struct {
 func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 	var (
 		service     string
+		target      string
 		jsonOut     bool
 		writeDir    string
 		payloadOnly bool
@@ -46,14 +47,17 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 			"individual assessment step, using monotonic sub-millisecond durations.\n\n" +
 			"Takes the path to a compiled plugin binary — the plugin runs as a separate " +
 			"process, so build it first (`make build`, or `go build -o <name> .`) and pass " +
-			"the resulting executable. The named --service must exist in the config file so " +
-			"the plugin has its vars, catalogs, and applicability.",
+			"the resulting executable. The named --target (or its legacy alias --service) " +
+			"must exist in the config file so the plugin has its vars, catalogs, and applicability.",
 		Args: cobra.ExactArgs(1),
 		// runtime failures shouldn't reprint usage text
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if target != "" {
+				service = target
+			}
 			if service == "" {
-				return fmt.Errorf("--service is required: the plugin needs a configured service to evaluate")
+				return fmt.Errorf("--target is required: the plugin needs a configured target to evaluate")
 			}
 			binPath, err := resolvePluginBinary(args[0])
 			if err != nil {
@@ -87,7 +91,8 @@ func benchmarkCmd(writerFn func() Writer) *cobra.Command {
 			return benchmarkRunError(exitCode)
 		},
 	}
-	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (required)")
+	benchmarkCmd.Flags().StringVarP(&service, "service", "s", "", "Named service from the config to evaluate (alias for --target)")
+	benchmarkCmd.Flags().StringVar(&target, "target", "", "Named target from the config to evaluate (required; wins over --service)")
 	benchmarkCmd.Flags().BoolVar(&jsonOut, "json", false, "Emit the machine-readable benchmark report as JSON (for diffing runs in CI)")
 	benchmarkCmd.Flags().StringVarP(&writeDir, "write-directory", "w", "", "Directory for the run's results and report (default: a temp directory)")
 	benchmarkCmd.Flags().BoolVar(&payloadOnly, "payload-only", false, "Stop after payload retrieval and time only the loader (skip assessment steps)")

--- a/command/harness/benchmark_test.go
+++ b/command/harness/benchmark_test.go
@@ -21,21 +21,41 @@ func TestGetBenchmarkCmd_Shape(t *testing.T) {
 	if cmd.Use != "benchmark <plugin-binary>" {
 		t.Errorf("unexpected Use: %q", cmd.Use)
 	}
-	for _, flag := range []string{"service", "json", "write-directory", "payload-only"} {
+	for _, flag := range []string{"service", "target", "json", "write-directory", "payload-only"} {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected --%s flag", flag)
 		}
 	}
 }
 
-func TestBenchmarkCmd_RequiresService(t *testing.T) {
+func TestBenchmarkCmd_RequiresTarget(t *testing.T) {
 	cmd := GetBenchmarkCmd(func() Writer { return &benchBufWriter{} })
 	cmd.SetArgs([]string{"/does/not/matter"})
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--service is required") {
-		t.Errorf("expected missing-service error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "--target is required") {
+		t.Errorf("expected missing-target error, got: %v", err)
+	}
+}
+
+// --target and its legacy alias --service both satisfy the requirement; when
+// both are given, --target wins. A bogus binary path keeps Execute from
+// launching a plugin while still proving flag resolution ran past validation.
+func TestBenchmarkCmd_TargetAliasAccepted(t *testing.T) {
+	for _, args := range [][]string{
+		{"/does/not/exist", "--target", "tgt1"},
+		{"/does/not/exist", "-s", "svc1"},
+		{"/does/not/exist", "--target", "tgt1", "-s", "svc1"},
+	} {
+		cmd := GetBenchmarkCmd(func() Writer { return &benchBufWriter{} })
+		cmd.SetArgs(args)
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		err := cmd.Execute()
+		if err == nil || strings.Contains(err.Error(), "is required") {
+			t.Errorf("args %v: expected binary-path error, got: %v", args, err)
+		}
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,8 @@ type Policy struct {
 func NewConfig(requiredVars []string) Config {
 	var errString string
 
-	serviceName := viper.GetString("service") // the currently running service; if empty, we're probably running from core
+	serviceName := TargetName() // the currently running target; if empty, we're probably running from core
+	svcKey := targetsKey()      // "targets" or its legacy "services" alias, whichever the config uses
 
 	write := viper.GetBool("write")                                         // defaults to true, but allow the user to disable file writing
 	output := strings.ToLower(strings.TrimSpace(viper.GetString("output"))) // defaults to yaml; can be set to json, sarif, or gemara
@@ -70,7 +71,7 @@ func NewConfig(requiredVars []string) Config {
 	benchmarkPayloadOnly := viper.GetBool("benchmark-payload-only")         // defaults to false; loader only, skip steps
 
 	vars := viper.GetStringMap("vars")
-	localVars := viper.GetStringMap(fmt.Sprintf("services.%s.vars", serviceName))
+	localVars := viper.GetStringMap(fmt.Sprintf("%s.%s.vars", svcKey, serviceName))
 	for key, value := range localVars {
 		// Overwrite or add local vars onto the global vars
 		vars[key] = value
@@ -89,7 +90,7 @@ func NewConfig(requiredVars []string) Config {
 	}
 
 	topLoglevel := viper.GetString("loglevel")
-	loglevel := viper.GetString(fmt.Sprintf("services.%s.loglevel", serviceName))
+	loglevel := viper.GetString(fmt.Sprintf("%s.%s.loglevel", svcKey, serviceName))
 	if loglevel == "" && topLoglevel != "" {
 		loglevel = topLoglevel
 	} else if loglevel == "" {
@@ -102,19 +103,19 @@ func NewConfig(requiredVars []string) Config {
 	}
 
 	topInvasive := viper.GetBool("invasive") // make sure we're actually using this to block changes
-	invasive := viper.GetBool(fmt.Sprintf("services.%s.invasive", serviceName))
+	invasive := viper.GetBool(fmt.Sprintf("%s.%s.invasive", svcKey, serviceName))
 	if !invasive && topInvasive {
 		invasive = topInvasive
 	}
 
 	topCatalogs := viper.GetStringSlice("policy.catalogs")
-	catalogs := viper.GetStringSlice(fmt.Sprintf("services.%s.policy.catalogs", serviceName))
+	catalogs := viper.GetStringSlice(fmt.Sprintf("%s.%s.policy.catalogs", svcKey, serviceName))
 	if len(catalogs) == 0 {
 		catalogs = topCatalogs
 	}
 
 	topApplicability := viper.GetStringSlice("policy.applicability")
-	applicability := viper.GetStringSlice(fmt.Sprintf("services.%s.policy.applicability", serviceName))
+	applicability := viper.GetStringSlice(fmt.Sprintf("%s.%s.policy.applicability", svcKey, serviceName))
 	if len(applicability) == 0 {
 		applicability = topApplicability
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,9 @@ func NewConfig(requiredVars []string) Config {
 	if serviceName != "" && (len(applicability) == 0 || len(catalogs) == 0) {
 		errString = fmt.Sprintf("invalid policy for service %s. applicability=%v catalogs=%v",
 			serviceName, len(applicability), len(catalogs))
+		if svcKey == "targets" && viper.IsSet("services."+serviceName) {
+			errString += fmt.Sprintf("; %q is defined under the legacy services key, which is ignored because a targets key is present", serviceName)
+		}
 	}
 
 	var missingVars []string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -616,6 +616,36 @@ targets:
 	}
 }
 
+func TestNewConfig_ErrorHintsWhenNameOnlyInLegacyServices(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBufferString(`
+targets:
+  tgt1:
+    policy:
+      catalogs: ["FINOS-CCC"]
+      applicability: ["tlp_green"]
+services:
+  svc1:
+    policy:
+      catalogs: ["FINOS-CCC"]
+      applicability: ["tlp_green"]
+`))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	viper.Set("service", "svc1")
+
+	cfg := NewConfig(nil)
+	if cfg.Error == nil {
+		t.Fatal("NewConfig() error = nil, want policy error with legacy-services hint")
+	}
+	if !strings.Contains(cfg.Error.Error(), "legacy services key") {
+		t.Errorf("error %q is missing the legacy services hint", cfg.Error.Error())
+	}
+}
+
 func TestNewConfig_DoesNotInheritBoundFlagDefaultIntoVars(t *testing.T) {
 	viper.Reset()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -544,6 +544,78 @@ services:
 	}
 }
 
+func TestNewConfig_TargetsConfigAlias(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBufferString(`
+targets:
+  my-target-1:
+    loglevel: debug
+    vars:
+      key1: value1
+    policy:
+      catalogs:
+        - FINOS-CCC
+      applicability: ["tlp_green"]
+`))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	viper.Set("target", "my-target-1")
+
+	cfg := NewConfig(nil)
+	if cfg.Error != nil {
+		t.Fatalf("NewConfig() error = %v, want nil", cfg.Error)
+	}
+	if cfg.ServiceName != "my-target-1" {
+		t.Errorf("ServiceName: got = %q, want = %q", cfg.ServiceName, "my-target-1")
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel: got = %q, want = %q", cfg.LogLevel, "debug")
+	}
+	if len(cfg.Policy.ControlCatalogs) != 1 || cfg.Policy.ControlCatalogs[0] != "FINOS-CCC" {
+		t.Errorf("ControlCatalogs: got = %v, want = [FINOS-CCC]", cfg.Policy.ControlCatalogs)
+	}
+	if got := cfg.GetString("key1"); got != "value1" {
+		t.Errorf("Vars[key1]: got = %q, want = %q", got, "value1")
+	}
+}
+
+func TestNewConfig_TargetWinsOverService(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBufferString(`
+services:
+  legacy-service:
+    policy:
+      catalogs: ["LEGACY"]
+      applicability: ["legacy"]
+targets:
+  my-target-1:
+    policy:
+      catalogs: ["FINOS-CCC"]
+      applicability: ["tlp_green"]
+`))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	viper.Set("service", "legacy-service")
+	viper.Set("target", "my-target-1")
+
+	cfg := NewConfig(nil)
+	if cfg.Error != nil {
+		t.Fatalf("NewConfig() error = %v, want nil", cfg.Error)
+	}
+	if cfg.ServiceName != "my-target-1" {
+		t.Errorf("ServiceName: got = %q, want = %q", cfg.ServiceName, "my-target-1")
+	}
+	if len(cfg.Policy.ControlCatalogs) != 1 || cfg.Policy.ControlCatalogs[0] != "FINOS-CCC" {
+		t.Errorf("ControlCatalogs: got = %v, want = [FINOS-CCC]", cfg.Policy.ControlCatalogs)
+	}
+}
+
 func TestNewConfig_DoesNotInheritBoundFlagDefaultIntoVars(t *testing.T) {
 	viper.Reset()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/config/getters.go
+++ b/config/getters.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -23,11 +24,45 @@ func AutoInstall() bool {
 	return viper.GetBool("autoinstall")
 }
 
+// targetFlags holds the flag set registered by command.SetRunFlags so
+// TargetName can rank an explicitly passed --target/--service above env and
+// config values. Viper cannot arbitrate that itself: "target" and "service"
+// are distinct keys, so its per-key flag-over-env precedence never compares
+// one key's flag against the other key's env var.
+var targetFlags *pflag.FlagSet
+
+// BindTargetFlags registers the flag set containing the "target" and "service"
+// flags so TargetName can give explicitly passed flags top precedence.
+func BindTargetFlags(fs *pflag.FlagSet) {
+	targetFlags = fs
+}
+
+// changedFlagValue returns the named flag's value only when the flag was
+// explicitly set on the command line.
+func changedFlagValue(name string) (string, bool) {
+	if targetFlags == nil {
+		return "", false
+	}
+	f := targetFlags.Lookup(name)
+	if f == nil || !f.Changed {
+		return "", false
+	}
+	return f.Value.String(), true
+}
+
 // TargetName returns the name of the target being executed, resolved from the
-// "target" key with fallback to the legacy "service" alias. When both are set,
-// "target" wins. Reads flag, PVTR_TARGET/PVTR_SERVICE env, and config values
-// through the same viper state as NewConfig (e.g. after command.ReadConfig()).
+// "target" key with fallback to the legacy "service" alias. Explicitly passed
+// flags outrank env and config values regardless of which alias they use, so a
+// plugin subprocess launched with --service is immune to an inherited
+// PVTR_TARGET and an operator's -s overrides a config-file target. Within the
+// same tier, "target" wins over "service".
 func TargetName() string {
+	if name, ok := changedFlagValue("target"); ok && name != "" {
+		return name
+	}
+	if name, ok := changedFlagValue("service"); ok && name != "" {
+		return name
+	}
 	if name := viper.GetString("target"); name != "" {
 		return name
 	}
@@ -35,10 +70,13 @@ func TargetName() string {
 }
 
 // targetsKey returns the config key holding the target definitions: "targets"
-// when present, otherwise the legacy "services" alias. When both are present,
-// "targets" wins outright; the two maps are never merged.
+// when it holds a non-empty map, otherwise the legacy "services" alias. When
+// both maps are populated, "targets" wins outright; the two maps are never
+// merged. Gating on a non-empty map rather than key presence keeps a stray
+// PVTR_TARGETS env var, an emptied-out `targets:` block, or a mistyped scalar
+// from silently masking a populated `services:` map.
 func targetsKey() string {
-	if viper.IsSet("targets") {
+	if len(viper.GetStringMap("targets")) > 0 {
 		return "targets"
 	}
 	return "services"

--- a/config/getters.go
+++ b/config/getters.go
@@ -23,16 +23,38 @@ func AutoInstall() bool {
 	return viper.GetBool("autoinstall")
 }
 
-// GetServices returns the services map from config (service name -> service config).
+// TargetName returns the name of the target being executed, resolved from the
+// "target" key with fallback to the legacy "service" alias. When both are set,
+// "target" wins. Reads flag, PVTR_TARGET/PVTR_SERVICE env, and config values
+// through the same viper state as NewConfig (e.g. after command.ReadConfig()).
+func TargetName() string {
+	if name := viper.GetString("target"); name != "" {
+		return name
+	}
+	return viper.GetString("service")
+}
+
+// targetsKey returns the config key holding the target definitions: "targets"
+// when present, otherwise the legacy "services" alias. When both are present,
+// "targets" wins outright; the two maps are never merged.
+func targetsKey() string {
+	if viper.IsSet("targets") {
+		return "targets"
+	}
+	return "services"
+}
+
+// GetServices returns the targets map from config (target name -> target config),
+// read from the "targets" key or its legacy "services" alias.
 // It reads from the same viper state as NewConfig (e.g. after command.ReadConfig()).
 func GetServices() map[string]interface{} {
-	return viper.GetStringMap("services")
+	return viper.GetStringMap(targetsKey())
 }
 
 // GetServicePlugin returns the plugin name for the given service.
 // It reads from the same viper state as NewConfig (e.g. after command.ReadConfig()).
 func GetServicePlugin(serviceName string) string {
-	return viper.GetString("services." + serviceName + ".plugin")
+	return viper.GetString(targetsKey() + "." + serviceName + ".plugin")
 }
 
 // GetServiceVersion returns the optional pinned plugin version for the given
@@ -46,7 +68,7 @@ func GetServicePlugin(serviceName string) string {
 // the "v"-prefixed string — surfacing a confusing "no version" error for what is
 // just a formatting difference.
 func GetServiceVersion(serviceName string) string {
-	return normalizeVersion(viper.GetString("services." + serviceName + ".version"))
+	return normalizeVersion(viper.GetString(targetsKey() + "." + serviceName + ".version"))
 }
 
 // normalizeVersion strips a single leading "v" when it precedes a digit (the

--- a/config/getters_test.go
+++ b/config/getters_test.go
@@ -315,6 +315,93 @@ func TestGetServicePlugin(t *testing.T) {
 	}
 }
 
+func TestTargetName(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		service string
+		want    string
+	}{
+		{name: "target only", target: "tgt-1", want: "tgt-1"},
+		{name: "service only", service: "svc-1", want: "svc-1"},
+		{name: "target wins over service", target: "tgt-1", service: "svc-1", want: "tgt-1"},
+		{name: "neither set", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			if tt.target != "" {
+				viper.Set("target", tt.target)
+			}
+			if tt.service != "" {
+				viper.Set("service", tt.service)
+			}
+			if got := TargetName(); got != tt.want {
+				t.Errorf("TargetName() = %q, want = %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTargetName_FromEnv(t *testing.T) {
+	withEnvAwareViper(t)
+	t.Setenv("PVTR_TARGET", "env-target")
+	if got := TargetName(); got != "env-target" {
+		t.Errorf("TargetName() = %q, want = %q", got, "env-target")
+	}
+}
+
+func TestGetServices_TargetsAlias(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("targets", map[string]interface{}{
+		"tgt1": map[string]interface{}{"plugin": "my-plugin"},
+	})
+	got := GetServices()
+	if len(got) != 1 {
+		t.Fatalf("GetServices() returned %d entries, want 1", len(got))
+	}
+	if _, ok := got["tgt1"]; !ok {
+		t.Error("GetServices() missing key tgt1")
+	}
+}
+
+func TestGetServices_TargetsWinsOverServices(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("services", map[string]interface{}{
+		"svc1": map[string]interface{}{"plugin": "legacy-plugin"},
+	})
+	viper.Set("targets", map[string]interface{}{
+		"tgt1": map[string]interface{}{"plugin": "my-plugin"},
+	})
+	got := GetServices()
+	if _, ok := got["tgt1"]; !ok {
+		t.Error("GetServices() missing key tgt1 from targets")
+	}
+	if _, ok := got["svc1"]; ok {
+		t.Error("GetServices() included svc1 from services; targets should win, not merge")
+	}
+}
+
+func TestGetServicePlugin_TargetsAlias(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("targets", map[string]interface{}{
+		"tgt1": map[string]interface{}{"plugin": "ossf/pvtr-github-repo-scanner", "version": "v1.4.0"},
+	})
+	if got := GetServicePlugin("tgt1"); got != "ossf/pvtr-github-repo-scanner" {
+		t.Errorf("GetServicePlugin(%q) = %q, want ossf/pvtr-github-repo-scanner", "tgt1", got)
+	}
+	if got := GetServiceVersion("tgt1"); got != "1.4.0" {
+		t.Errorf("GetServiceVersion(%q) = %q, want 1.4.0", "tgt1", got)
+	}
+}
+
 func BenchmarkGetVar_Hit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _ = testConfig.GetVar("stringKey")

--- a/config/getters_test.go
+++ b/config/getters_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -341,6 +343,96 @@ func TestTargetName(t *testing.T) {
 				t.Errorf("TargetName() = %q, want = %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// bindTestFlags registers a run-style flag set with the config package the way
+// command.SetRunFlags does, so TargetName sees flag Changed state. Call AFTER
+// any viper.Reset in the test, since Reset drops viper's flag bindings.
+func bindTestFlags(t *testing.T) *pflag.FlagSet {
+	t.Helper()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.StringP("service", "s", "", "")
+	fs.String("target", "", "")
+	_ = viper.BindPFlag("service", fs.Lookup("service"))
+	_ = viper.BindPFlag("target", fs.Lookup("target"))
+	BindTargetFlags(fs)
+	t.Cleanup(func() { BindTargetFlags(nil) })
+	return fs
+}
+
+func TestTargetName_ChangedTargetFlagBeatsServiceFlag(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	fs := bindTestFlags(t)
+	if err := fs.Set("service", "flag-service"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Set("target", "flag-target"); err != nil {
+		t.Fatal(err)
+	}
+	if got := TargetName(); got != "flag-target" {
+		t.Errorf("TargetName() = %q, want = %q", got, "flag-target")
+	}
+}
+
+func TestTargetName_ChangedServiceFlagBeatsEnvTarget(t *testing.T) {
+	withEnvAwareViper(t)
+	fs := bindTestFlags(t)
+	t.Setenv("PVTR_TARGET", "env-target")
+	if err := fs.Set("service", "flag-service"); err != nil {
+		t.Fatal(err)
+	}
+	if got := TargetName(); got != "flag-service" {
+		t.Errorf("TargetName() = %q, want = %q (explicit flag must beat inherited env)", got, "flag-service")
+	}
+}
+
+func TestTargetName_ChangedServiceFlagBeatsConfigTarget(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	if err := viper.ReadConfig(bytes.NewBufferString("target: config-target\n")); err != nil {
+		t.Fatal(err)
+	}
+	fs := bindTestFlags(t)
+	if err := fs.Set("service", "flag-service"); err != nil {
+		t.Fatal(err)
+	}
+	if got := TargetName(); got != "flag-service" {
+		t.Errorf("TargetName() = %q, want = %q (explicit flag must beat config file)", got, "flag-service")
+	}
+}
+
+func TestTargetsKey_EnvTargetsDoesNotMaskServices(t *testing.T) {
+	withEnvAwareViper(t)
+	t.Setenv("PVTR_TARGETS", "oops")
+	viper.Set("services", map[string]interface{}{
+		"svc1": map[string]interface{}{"plugin": "my-plugin"},
+	})
+	if got := GetServicePlugin("svc1"); got != "my-plugin" {
+		t.Errorf("GetServicePlugin(%q) = %q, want my-plugin (PVTR_TARGETS must not mask services)", "svc1", got)
+	}
+	if got := GetServices(); len(got) != 1 {
+		t.Errorf("GetServices() returned %d entries, want 1", len(got))
+	}
+}
+
+func TestTargetsKey_EmptyTargetsMapFallsBackToServices(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBufferString(`
+targets: {}
+services:
+  svc1:
+    plugin: my-plugin
+`))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	if got := GetServicePlugin("svc1"); got != "my-plugin" {
+		t.Errorf("GetServicePlugin(%q) = %q, want my-plugin (empty targets map must not mask services)", "svc1", got)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,18 @@ targets:
 
 `targets:` names the things a run evaluates. The `services:` key and the
 `--service` / `-s` flag are legacy aliases kept for compatibility: `services:`
-works exactly like `targets:`, and `--service` works like `--target`. When both
-are present, `target` / `targets:` win (`targets:` replaces `services:`
-entirely; the maps are not merged). Prefer `targets:` and `--target` in new
-configs; `--target` has no shorthand because `-t` belongs to `--test-suites`.
+works exactly like `targets:`, and `--service` works like `--target`.
+
+Resolution rules:
+
+- An explicitly passed flag (`--target` or `--service`) always wins over
+  `PVTR_TARGET` / `PVTR_SERVICE` env vars and config-file values, regardless
+  of which alias it uses. Within the same source, `target` wins over `service`.
+- A non-empty `targets:` map replaces `services:` entirely; the two maps are
+  never merged. An empty or absent `targets:` falls back to `services:`.
+
+Prefer `targets:` and `--target` in new configs; `--target` has no shorthand
+because `-t` belongs to `--test-suites`.
 
 ## Publishing from CI
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,11 +29,20 @@ Example `config.yml`:
 hub-url: https://hub.preview.grc.store
 autoinstall: true
 binaries-path: ./.privateer/bin
-services:
-  my-service:
+targets:
+  my-target:
     plugin: ossf/pvtr-github-repo-scanner
     version: 1.4.0   # optional; omit for the latest installed version
 ```
+
+## Targets and the legacy `services` alias
+
+`targets:` names the things a run evaluates. The `services:` key and the
+`--service` / `-s` flag are legacy aliases kept for compatibility: `services:`
+works exactly like `targets:`, and `--service` works like `--target`. When both
+are present, `target` / `targets:` win (`targets:` replaces `services:`
+entirely; the maps are not merged). Prefer `targets:` and `--target` in new
+configs; `--target` has no shorthand because `-t` belongs to `--test-suites`.
 
 ## Publishing from CI
 


### PR DESCRIPTION
Closes #276

## What/Why

Adds a `--target` flag and a `targets:` config key as aliases for `--service` and `services:`, giving consumers a migration path toward the eventual deprecation of the service naming. `pvtr benchmark` also accepts `--target` alongside its existing `-s`.

Resolution rules: an explicitly passed flag (either alias) outranks `PVTR_TARGET`/`PVTR_SERVICE` env vars and config-file values, so plugin subprocesses launched with `--service=<name>` are immune to an inherited `PVTR_TARGET`. Within the same source, `target` wins over `service`. A non-empty `targets:` map replaces `services:` entirely (no merging); an empty or absent `targets:` falls back to `services:`.

## Proof it works

Full `go test ./...` suite passes. Regression tests exercise real flag/env/config tiers (not viper's override layer): a changed `--service` beats `PVTR_TARGET` and a config-file `target:`, a changed `--target` beats `--service`, a stray `PVTR_TARGETS` or `targets: {}` does not mask a populated `services:` map, the invalid-policy error hints when a name exists only under an ignored legacy `services:` key, and benchmark accepts `--target`/`-s`. Standalone reproductions of the two env-precedence bugs found in review now show correct values.

## Risk + AI role

Low. Purely additive; legacy `service`/`services:` behavior is unchanged when the target keys are absent. Implementation and tests AI-generated, then AI-reviewed with two independent review passes whose findings were fixed and human-verified.

## Review focus

The flag-registration seam (`config.BindTargetFlags` called from `SetRunFlags`) that lets `TargetName` rank explicit flags above env/config, and whether that tiered precedence matches the intent in #276. Also: `--target` has no shorthand because `-t` belongs to `--test-suites`.