### PR TITLE
feat(command): concurrent plugin execution via --concurrency

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -61,6 +61,11 @@ func SetRunFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolP("include-payload", "", false, "Include the raw evaluated payload in results output (large; useful for tracing)")
 	_ = viper.BindPFlag("include-payload", cmd.PersistentFlags().Lookup("include-payload"))
+
+	// Only meaningful to harnesses running multiple plugins; a plugin binary
+	// carrying this flag simply ignores it.
+	cmd.PersistentFlags().Int("concurrency", 1, "Max plugins to run in parallel; 0 means one per CPU; capped at 100 or the CPU count, whichever is larger; must not be negative")
+	_ = viper.BindPFlag("concurrency", cmd.PersistentFlags().Lookup("concurrency"))
 }
 
 // ReadConfig reads the configuration file. If --config is explicitly provided,

--- a/command/base_scope_test.go
+++ b/command/base_scope_test.go
@@ -21,6 +21,7 @@ var runScopedFlags = map[string]string{
 	"silent":          "",
 	"write":           "",
 	"include-payload": "",
+	"concurrency":     "",
 }
 
 // TestSetBase_RegistersUniversalFlags asserts SetBase keeps the truly universal

--- a/command/run.go
+++ b/command/run.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+	"strconv"
 
 	hclog "github.com/hashicorp/go-hclog"
 	hcplugin "github.com/hashicorp/go-plugin"
 	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/privateerproj/privateer-sdk/shared"
 )
@@ -84,38 +87,110 @@ func Run(logger hclog.Logger, getPlugins func() []*PluginPkg) (exitCode int) {
 		return BadUsage
 	}
 
-	var runCount int
-	for _, pluginPkg := range toRun {
-		serviceName := pluginPkg.ServiceTarget
-		runCount++
-		client := newClient(pluginPkg.Command, logger)
-		var rpcClient hcplugin.ClientProtocol
-		rpcClient, err := client.Client()
-		if err != nil {
-			logger.Error(fmt.Sprintf("internal error while initializing %s RPC client: %s", serviceName, err))
-			pluginPkg.closeClient(serviceName, client, logger)
+	// runParallel and runSequential are mock tested with runFunc
+	// as a param, so we need to wrap runOne here to use it for real.
+	run := func(num int, pluginPkg *PluginPkg) (int, bool) {
+		return runOne(logger, num, pluginPkg)
+	}
+	limit, err := concurrencyLimit()
+	if err != nil {
+		logger.Error(err.Error())
+		return BadUsage
+	}
+	if limit != 1 {
+		return runParallel(toRun, limit, run)
+	}
+	return runSequential(toRun, run)
+}
+
+// concurrencyLimit returns the requested plugin pool size, or an error for
+// anything that is not a non-negative integer.
+func concurrencyLimit() (int, error) {
+	viper.SetDefault("concurrency", 1)
+	raw := viper.GetString("concurrency")
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit < 0 {
+		return 0, fmt.Errorf("concurrency must be a non-negative integer, got %q", raw)
+	}
+	return limit, nil
+}
+
+// runSequential executes plugins one at a time in input order, merging exit
+// codes by severity. It returns immediately only on a host-level failure.
+func runSequential(toRun []*PluginPkg, run runFunc) (exitCode int) {
+	for i, pluginPkg := range toRun {
+		code, fatal := run(i+1, pluginPkg)
+		if fatal {
 			return InternalError
 		}
-		var rawPlugin interface{}
-		rawPlugin, err = rpcClient.Dispense(shared.PluginName)
-		if err != nil {
-			logger.Error(fmt.Sprintf("internal error while dispensing RPC client: %s", err.Error()))
-			pluginPkg.closeClient(serviceName, client, logger)
-			return InternalError
-		}
-		plugin := rawPlugin.(shared.Pluginer)
-		logger.Trace(fmt.Sprintf("Starting Plugin %v: %s", runCount, pluginPkg.Name))
-		pluginExitCode, response := plugin.Start()
-		if response != nil {
-			pluginPkg.Error = fmt.Errorf("plugin %s: %v", serviceName, response)
-		}
-		pluginPkg.Successful = pluginExitCode == TestPass
-		if !pluginPkg.Successful {
-			exitCode = mergeExitCode(exitCode, pluginExitCode)
-		}
-		pluginPkg.closeClient(serviceName, client, logger)
+		exitCode = mergeExitCode(exitCode, code)
 	}
 	return exitCode
+}
+
+// maxConcurrency is the safety cap on an explicit limit: 100, or the CPU
+// count when the host is larger than that. It exists so a goofy config value
+// can't fork-bomb the machine, while a host big enough to handle the request
+// is allowed to.
+const maxConcurrency = 100
+
+// runParallel executes plugins concurrently, at most limit at a time. A limit
+// of 0 or less means one per CPU. Unlike the sequential path, it never aborts early.
+func runParallel(toRun []*PluginPkg, limit int, run runFunc) (exitCode int) {
+	if limit <= 0 {
+		limit = runtime.NumCPU()
+	}
+	limit = min(limit, max(maxConcurrency, runtime.NumCPU()))
+	codes := make([]int, len(toRun))
+	var g errgroup.Group
+	g.SetLimit(limit)
+	for i, pluginPkg := range toRun {
+		g.Go(func() error {
+			codes[i], _ = run(i+1, pluginPkg)
+			return nil
+		})
+	}
+	_ = g.Wait() // run never returns an error; Wait is only the barrier
+	for _, code := range codes {
+		exitCode = mergeExitCode(exitCode, code)
+	}
+	return exitCode
+}
+
+// runFunc executes one plugin end to end. runOne is the only production
+// implementation; this is a parameter so the sequencing and pooling can
+// be mock tested without spawning plugin subprocesses.
+type runFunc func(num int, pluginPkg *PluginPkg) (int, bool)
+
+// runOne executes a single plugin subprocess end to end recording the outcome on pluginPkg.
+// It returns the exit code and whether the failure was host-level.
+// It only touches pluginPkg's own fields, so distinct plugins are safe to run concurrently.
+func runOne(logger hclog.Logger, num int, pluginPkg *PluginPkg) (code int, fatal bool) {
+	serviceName := pluginPkg.ServiceTarget
+	client := newClient(pluginPkg.Command, logger)
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		logger.Error(fmt.Sprintf("internal error while initializing %s RPC client: %s", serviceName, err))
+		pluginPkg.closeClient(serviceName, client, logger)
+		return InternalError, true
+	}
+	rawPlugin, err := rpcClient.Dispense(shared.PluginName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("internal error while dispensing RPC client: %s", err.Error()))
+		pluginPkg.closeClient(serviceName, client, logger)
+		return InternalError, true
+	}
+	plugin := rawPlugin.(shared.Pluginer)
+	logger.Trace(fmt.Sprintf("Starting Plugin %v: %s", num, pluginPkg.Name))
+
+	pluginExitCode, response := plugin.Start()
+	if response != nil {
+		pluginPkg.Error = fmt.Errorf("plugin %s: %v", serviceName, response)
+	}
+	pluginPkg.Successful = pluginExitCode == TestPass
+	pluginPkg.closeClient(serviceName, client, logger)
+	return pluginExitCode, false
 }
 
 // newClient handles the lifecycle of a plugin application.

--- a/command/run_test.go
+++ b/command/run_test.go
@@ -1,6 +1,13 @@
 package command
 
-import "testing"
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/viper"
+)
 
 func TestMergeExitCode(t *testing.T) {
 	tests := []struct {
@@ -120,4 +127,179 @@ func TestPlanRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+// pkgs builds n minimal PluginPkgs; the run funcs under test never touch their
+// fields beyond identity, so empty structs suffice.
+func pkgs(n int) []*PluginPkg {
+	out := make([]*PluginPkg, n)
+	for i := range out {
+		out[i] = &PluginPkg{}
+	}
+	return out
+}
+
+func TestRunSequential(t *testing.T) {
+	t.Run("merges exit codes in order", func(t *testing.T) {
+		codes := []int{TestPass, TestFail, TestPass}
+		var ran []int
+		got := runSequential(pkgs(3), func(num int, _ *PluginPkg) (int, bool) {
+			ran = append(ran, num)
+			return codes[num-1], false
+		})
+		if got != TestFail {
+			t.Errorf("exit = %d, want %d", got, TestFail)
+		}
+		if len(ran) != 3 || ran[0] != 1 || ran[1] != 2 || ran[2] != 3 {
+			t.Errorf("ran = %v, want [1 2 3]", ran)
+		}
+	})
+
+	t.Run("plugin internal error merges and the run continues", func(t *testing.T) {
+		var calls int
+		got := runSequential(pkgs(3), func(num int, _ *PluginPkg) (int, bool) {
+			calls++
+			if num == 2 {
+				return InternalError, false
+			}
+			return TestPass, false
+		})
+		if got != InternalError {
+			t.Errorf("exit = %d, want %d", got, InternalError)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3 (a plugin's own InternalError must not abort)", calls)
+		}
+	})
+
+	t.Run("host-level failure aborts", func(t *testing.T) {
+		var calls int
+		got := runSequential(pkgs(3), func(num int, _ *PluginPkg) (int, bool) {
+			calls++
+			if num == 2 {
+				return InternalError, true
+			}
+			return TestPass, false
+		})
+		if got != InternalError {
+			t.Errorf("exit = %d, want %d", got, InternalError)
+		}
+		if calls != 2 {
+			t.Errorf("calls = %d, want 2 (abort after the failing plugin)", calls)
+		}
+	})
+}
+
+// TestConcurrencyLimit covers the default Run relies on: an unset key must read
+// as 1 (sequential), not viper's zero value — and invalid values must fail
+// closed into an error (Run returns BadUsage), never fall through to 0 and
+// silently switch on parallel execution. Valid values pass through — Run routes
+// on them with a single `!= 1`, and both arms are covered by TestRunSequential
+// and TestRunParallel.
+func TestConcurrencyLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		set     any // nil leaves the key unset
+		want    int
+		wantErr bool
+	}{
+		{"unset key defaults to 1", nil, 1, false},
+		{"explicit 1", 1, 1, false},
+		{"0 passes through", 0, 0, false},
+		{"above 1 passes through", 4, 4, false},
+		{"non-integer fails closed", "banana", 0, true},
+		{"negative fails closed", -1, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetViper()
+			t.Cleanup(resetViper)
+			if tt.set != nil {
+				viper.Set("concurrency", tt.set)
+			}
+			got, err := concurrencyLimit()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("concurrencyLimit() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("concurrencyLimit() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunParallel(t *testing.T) {
+	t.Run("bounds concurrency and merges all results", func(t *testing.T) {
+		var inFlight, peak, calls atomic.Int32
+		got := runParallel(pkgs(6), 2, func(num int, _ *PluginPkg) (int, bool) {
+			calls.Add(1)
+			n := inFlight.Add(1)
+			for p := peak.Load(); n > p; p = peak.Load() {
+				if peak.CompareAndSwap(p, n) {
+					break
+				}
+			}
+			defer inFlight.Add(-1)
+			if num == 3 {
+				// fatal=true: even a host-level failure must not abort parallel mode.
+				return InternalError, true
+			}
+			return TestPass, false
+		})
+		if got != InternalError {
+			t.Errorf("exit = %d, want %d (no early abort in parallel mode)", got, InternalError)
+		}
+		if calls.Load() != 6 {
+			t.Errorf("calls = %d, want 6", calls.Load())
+		}
+		if peak.Load() > 2 {
+			t.Errorf("peak in-flight = %d, want <= 2", peak.Load())
+		}
+	})
+
+	t.Run("limit 0 runs one per CPU", func(t *testing.T) {
+		n := runtime.NumCPU()
+		var barrier sync.WaitGroup
+		barrier.Add(n)
+		got := runParallel(pkgs(n), 0, func(int, *PluginPkg) (int, bool) {
+			// Deadlocks (and fails the test by timeout) unless all NumCPU run
+			// simultaneously.
+			barrier.Done()
+			barrier.Wait()
+			return TestPass, false
+		})
+		if got != TestPass {
+			t.Errorf("exit = %d, want %d", got, TestPass)
+		}
+	})
+
+	// The safety cap applies to an explicit limit: maxConcurrency, or NumCPU on
+	// hosts larger than that. Every worker blocks until cap are in flight, so
+	// an uncapped pool would admit all n and show a peak above the ceiling
+	// rather than deadlocking. Sizing the barrier off the effective cap (not a
+	// constant) keeps this from hanging on >100-core hosts.
+	t.Run("caps an explicit limit at max(maxConcurrency, NumCPU)", func(t *testing.T) {
+		cap := max(maxConcurrency, runtime.NumCPU())
+		n := cap + 10
+		var inFlight, peak atomic.Int32
+		var once sync.Once
+		release := make(chan struct{})
+		runParallel(pkgs(n), n, func(int, *PluginPkg) (int, bool) {
+			cur := inFlight.Add(1)
+			for p := peak.Load(); cur > p; p = peak.Load() {
+				if peak.CompareAndSwap(p, cur) {
+					break
+				}
+			}
+			if cur >= int32(cap) {
+				once.Do(func() { close(release) })
+			}
+			<-release
+			inFlight.Add(-1)
+			return TestPass, false
+		})
+		if int(peak.Load()) != cap {
+			t.Errorf("peak in-flight = %d, want exactly %d", peak.Load(), cap)
+		}
+	})
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,9 @@ defaults.
 ## Harness keys
 
 These drive the harness (`pvtr install` / `publish` / `run` / `list`), not a
-plugin serving itself. Their flags are registered by `harness.SetHarnessFlags`
-on the CLI root.
+plugin serving itself. Their flags sit on the CLI root, except `--concurrency`,
+which only affects `pvtr run` (the flag also appears on plugin binaries, which
+share the flag set, but a plugin serving itself ignores it).
 
 <!-- markdownlint-disable MD013 -->
 
@@ -17,6 +18,7 @@ on the CLI root.
 | --- | --- | --- | --- | --- |
 | `hub-url` | `--hub-url` | `PVTR_HUB_URL` | `https://hub.grc.store` | Hub base URL. Registry host is discovered from it. |
 | `autoinstall` | `--autoinstall` | `PVTR_AUTOINSTALL` | `false` | Auto-install missing plugins before `pvtr run`. |
+| `concurrency` | `pvtr run --concurrency` | `PVTR_CONCURRENCY` | `1` | Max plugins to run at once. `1` is sequential; `0` means one per CPU. Explicit values are capped at `100` or the CPU count, whichever is larger. Negative or non-integer values are rejected as bad usage. Above `1`, plugin console output may interleave. |
 | `binaries-path` | -- | `PVTR_BINARIES_PATH` | -- | Plugin install directory. Config/env only. |
 | `benchmark` | -- | `PVTR_BENCHMARK` | `false` | Time the loader and every step; write `benchmark.json` next to results. Set by `pvtr benchmark`; env only for direct plugin runs. |
 | `benchmark-payload-only` | -- | `PVTR_BENCHMARK_PAYLOAD_ONLY` | `false` | Time the loader only and skip assessment steps. Ignored unless `benchmark` is set. |


### PR DESCRIPTION
**Plugins can now run in parallel. Off by default — nothing changes unless you ask for it.**

## The setting

New `concurrency` setting. Set it three ways: `--concurrency` flag, `PVTR_CONCURRENCY` env var, or the `concurrency` key in `config.yml`.

| value | what happens |
|-------|--------------|
| `1` **(default)** | One at a time, in order. **Identical to today.** |
| `0` | One per CPU |
| `N` | At most N at once |
| negative or non-integer | Rejected as `BadUsage` |

An explicit `N` is capped at `100` or the CPU count, whichever is larger: a goofy config value can't fork-bomb a small machine, but a host big enough to handle the request is allowed to.

## What changed in the code

- Per-plugin execution moved out of `Run`'s loop into a new `runOne`.
- `runOne` touches only its own `PluginPkg` fields, so plugins can't race each other. Verified under `-race`.
- `runParallel` uses `errgroup.SetLimit` — same idiom as the concurrent installer in `internal/install/fromconfig.go`. No hand-rolled semaphore.
- Exit codes still merge through the existing `mergeExitCode` severity table. Most severe still wins.
- The value is read via `strconv.Atoi`, not `viper.GetInt` — GetInt swallows cast errors as `0`, which would let a typo'd env var silently enable parallel mode. Invalid values fail closed to `BadUsage`.
- The default is set via `viper.SetDefault` inside `Run`, not just on the flag. Otherwise a harness that binds its own flags would inherit viper's zero value — and `0` means *one per CPU*.

## Things to know before reviewing

**Backward compatible.** Default `1` reproduces the current code path exactly. No plugin-side change needed. Existing community plugins are unaffected.

**Early-abort behavior differs by mode.** Sequential aborts only on a *host-level* failure (the plugin subprocess couldn't be started or dispensed); a plugin's own exit code, `InternalError` included, merges and the run continues — this is the historical behavior. Parallel mode never aborts early at all: every plugin runs to completion, so one plugin's failure can't hide another's results. This difference is deliberate.

**Output can interleave.** Plugins share `SyncStdout` / `SyncStderr`, so at `concurrency != 1` their console output may interleave. This is the main reason sequential stays the default. Result *files* are unaffected — machine-readable output stays standardized.

**The flag shows up on plugin binaries too.** They share `SetRunFlags`. It's a harmless no-op there, since a plugin runs itself rather than a set of plugins. Now noted in `docs/configuration.md` as well as the code comment.

**Heads up on the default.** The now-deprecated `privateer-enterprise` runner defaulted this to `0` (one per CPU). The SDK intentionally defaults to `1` for backward compatibility; with enterprise retired, sequential-by-default is the only supported behavior. A harness wanting a different default must `viper.Set` it — `SetDefault` here wins over an unchanged bound-flag default.

## Tests

Both helpers take the per-plugin execution as a function, so none of this needs go-plugin fakes.

- **Sequential** — exit-code merging, input ordering, abort on host-level failure only (a plugin's own `InternalError` continues).
- **Parallel** — peak in-flight never exceeds the limit, every plugin runs, most-severe code wins.
- **`limit 0`** — a `WaitGroup` barrier that only completes if every plugin genuinely runs at the same time.
- **Validation** — unset defaults to `1`; negative and non-integer values fail closed.

`go vet ./...`, `go build ./...`, and the full `go test ./...` suite all pass. New tests also pass under `-race`.

## Origin

Inspired by the parallel runner in the private `privateer-enterprise` repo, which is now deprecated — this PR upstreams the feature as its replacement, reworked to fit the SDK's existing idioms.

## Review checklist

- [x] Output remains machine-readable and standardized
- [x] Backward-compatible with existing community-maintained plugins
- [x] Validations written for the new logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
